### PR TITLE
Improve Garden Farmers graphics

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -140,51 +140,101 @@ window.addEventListener('resize', () => {
 });
 
 // Lighting
-scene.add(new THREE.AmbientLight(0xffeedd, 0.6));
-const sun = new THREE.DirectionalLight(0xfff5cc, 1.2);
-sun.position.set(10, 20, 10);
+scene.add(new THREE.HemisphereLight(0xb0e0ff, 0x4a7a00, 0.7)); // sky/ground bounce
+const sun = new THREE.DirectionalLight(0xfff8e0, 1.6);
+sun.position.set(15, 25, 10);
 sun.castShadow = true;
 sun.shadow.mapSize.set(2048, 2048);
-sun.shadow.camera.left = -30; sun.shadow.camera.right = 30;
-sun.shadow.camera.top = 30;  sun.shadow.camera.bottom = -30;
+sun.shadow.camera.left = -35; sun.shadow.camera.right = 35;
+sun.shadow.camera.top = 35;  sun.shadow.camera.bottom = -35;
+sun.shadow.bias = -0.001;
 scene.add(sun);
+const fill = new THREE.DirectionalLight(0x8899ff, 0.35); // cool fill from opposite
+fill.position.set(-10, 8, -10);
+scene.add(fill);
 
 // ═══════════════════════════════════════
 //  FARM SCENE
 // ═══════════════════════════════════════
 const FARM_R = 18;
 
-// Outer ground
-const gGeo = new THREE.PlaneGeometry(80, 80);
-const gnd = new THREE.Mesh(gGeo, new THREE.MeshLambertMaterial({ color: 0x5aaa3a }));
-gnd.rotation.x = -Math.PI / 2; gnd.receiveShadow = true;
-scene.add(gnd);
+// Outer ground — canvas grass texture
+(function() {
+  const c = document.createElement('canvas'); c.width = 256; c.height = 256;
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#4a9a30'; ctx.fillRect(0, 0, 256, 256);
+  for (let i = 0; i < 600; i++) {
+    const x = Math.random()*256, y = Math.random()*256;
+    ctx.fillStyle = Math.random() > 0.5 ? '#3d8a25' : '#5cb040';
+    ctx.fillRect(x, y, 3, 3);
+  }
+  const tex = new THREE.CanvasTexture(c); tex.wrapS = tex.wrapT = THREE.RepeatWrapping; tex.repeat.set(8, 8);
+  const gnd = new THREE.Mesh(new THREE.PlaneGeometry(80, 80), new THREE.MeshStandardMaterial({ map: tex, roughness: 0.95, metalness: 0 }));
+  gnd.rotation.x = -Math.PI / 2; gnd.receiveShadow = true; scene.add(gnd);
+})();
 
-// Dirt farm circle
-const fGeo = new THREE.CircleGeometry(FARM_R, 40);
-const farm = new THREE.Mesh(fGeo, new THREE.MeshLambertMaterial({ color: 0x8B6914 }));
-farm.rotation.x = -Math.PI / 2; farm.position.y = 0.01; farm.receiveShadow = true;
-scene.add(farm);
+// Dirt farm circle — canvas soil texture
+(function() {
+  const c = document.createElement('canvas'); c.width = 256; c.height = 256;
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#7a5410'; ctx.fillRect(0, 0, 256, 256);
+  for (let i = 0; i < 800; i++) {
+    const x = Math.random()*256, y = Math.random()*256;
+    ctx.fillStyle = Math.random() > 0.5 ? '#6a4408' : '#8b6318';
+    ctx.fillRect(x, y, Math.random()*5+1, Math.random()*2+1);
+  }
+  const tex = new THREE.CanvasTexture(c); tex.wrapS = tex.wrapT = THREE.RepeatWrapping; tex.repeat.set(4, 4);
+  const farm = new THREE.Mesh(new THREE.CircleGeometry(FARM_R, 48), new THREE.MeshStandardMaterial({ map: tex, roughness: 0.98, metalness: 0 }));
+  farm.rotation.x = -Math.PI / 2; farm.position.y = 0.01; farm.receiveShadow = true; scene.add(farm);
+})();
 
-// Fence posts around edge
-for (let i = 0; i < 18; i++) {
-  const a = (i / 18) * Math.PI * 2;
-  const post = new THREE.Mesh(
-    new THREE.BoxGeometry(0.2, 0.8, 0.2),
-    new THREE.MeshLambertMaterial({ color: 0x5c3317 })
-  );
-  post.position.set(Math.cos(a) * FARM_R, 0.4, Math.sin(a) * FARM_R);
+// Fence posts + rails around edge
+const FENCE_MAT = new THREE.MeshStandardMaterial({ color: 0x8B5E3C, roughness: 0.9, metalness: 0 });
+const POST_N = 24;
+for (let i = 0; i < POST_N; i++) {
+  const a = (i / POST_N) * Math.PI * 2;
+  const post = new THREE.Mesh(new THREE.BoxGeometry(0.22, 1.1, 0.22), FENCE_MAT);
+  post.position.set(Math.cos(a) * FARM_R, 0.55, Math.sin(a) * FARM_R);
   post.castShadow = true; scene.add(post);
+  // Rail to next post
+  const a2 = ((i + 1) / POST_N) * Math.PI * 2;
+  const x1 = Math.cos(a) * FARM_R, z1 = Math.sin(a) * FARM_R;
+  const x2 = Math.cos(a2) * FARM_R, z2 = Math.sin(a2) * FARM_R;
+  const mid = new THREE.Vector3((x1+x2)/2, 0.85, (z1+z2)/2);
+  const len = Math.sqrt((x2-x1)**2 + (z2-z1)**2);
+  const rail = new THREE.Mesh(new THREE.BoxGeometry(len, 0.1, 0.1), FENCE_MAT);
+  rail.position.copy(mid); rail.rotation.y = -Math.atan2(z2-z1, x2-x1); scene.add(rail);
+  // Lower rail
+  const rail2 = rail.clone(); rail2.position.y = 0.45; scene.add(rail2);
 }
 
-// Barn (center)
+// Barn (center) — improved
 const barnGrp = new THREE.Group();
-const barnBody = new THREE.Mesh(new THREE.BoxGeometry(4, 3, 3), new THREE.MeshLambertMaterial({ color: 0xcc3333 }));
-barnBody.position.y = 1.5; barnBody.castShadow = true; barnGrp.add(barnBody);
-const barnRoof = new THREE.Mesh(new THREE.ConeGeometry(3, 2, 4), new THREE.MeshLambertMaterial({ color: 0x8B4513 }));
-barnRoof.position.y = 4; barnRoof.rotation.y = Math.PI / 4; barnRoof.castShadow = true; barnGrp.add(barnRoof);
-const barnDoor = new THREE.Mesh(new THREE.BoxGeometry(1, 1.5, 0.1), new THREE.MeshLambertMaterial({ color: 0x5C3317 }));
-barnDoor.position.set(0, 0.75, 1.55); barnGrp.add(barnDoor);
+const mkBarn = (geo, color, rx=0) => { const m = new THREE.Mesh(geo, new THREE.MeshStandardMaterial({ color, roughness:0.85, metalness:0 })); m.castShadow=true; m.receiveShadow=true; if(rx) m.rotation.y=rx; return m; };
+const barnBody = mkBarn(new THREE.BoxGeometry(5, 3.2, 3.5), 0xc0392b);
+barnBody.position.y = 1.6; barnGrp.add(barnBody);
+// Roof gable
+const barnRoof = mkBarn(new THREE.CylinderGeometry(0.01, 3.8, 2.5, 4), 0x7b3a10, Math.PI/4);
+barnRoof.position.y = 4.45; barnGrp.add(barnRoof);
+// White trim
+const trim = mkBarn(new THREE.BoxGeometry(5.1, 0.18, 3.6), 0xffffff);
+trim.position.y = 3.29; barnGrp.add(trim);
+// Door
+const barnDoor = mkBarn(new THREE.BoxGeometry(1.1, 1.9, 0.12), 0x5C3317);
+barnDoor.position.set(0, 0.95, 1.82); barnGrp.add(barnDoor);
+// Door arch top
+const arch = mkBarn(new THREE.CylinderGeometry(0.55, 0.55, 0.12, 8, 1, false, 0, Math.PI), 0x5C3317);
+arch.rotation.z = Math.PI/2; arch.position.set(0, 1.9, 1.82); barnGrp.add(arch);
+// Windows
+[-1.6, 1.6].forEach(x => {
+  const win = mkBarn(new THREE.BoxGeometry(0.7, 0.7, 0.1), 0x87ceeb);
+  win.position.set(x, 2.2, 1.82); barnGrp.add(win);
+  const wframe = mkBarn(new THREE.BoxGeometry(0.75, 0.75, 0.06), 0xffffff);
+  wframe.position.set(x, 2.2, 1.86); barnGrp.add(wframe);
+});
+// Chimney
+const chim = mkBarn(new THREE.BoxGeometry(0.4, 1.2, 0.4), 0x884422);
+chim.position.set(1.5, 5.2, 0); barnGrp.add(chim);
 scene.add(barnGrp);
 
 // Barn HP ring
@@ -198,16 +248,41 @@ function updateBarnRing() {
   scene.add(barnRing);
 }
 
-// Helper: make a tree
-function makeTree(x, z) {
+// Helper: make a tree with layered canopy
+function makeTree(x, z, scale=1) {
   const g = new THREE.Group();
-  const tr = new THREE.Mesh(new THREE.CylinderGeometry(0.2, 0.3, 1.5, 8), new THREE.MeshLambertMaterial({ color: 0x5C3317 }));
-  tr.position.y = 0.75; tr.castShadow = true; g.add(tr);
-  const lv = new THREE.Mesh(new THREE.ConeGeometry(1.2, 2.2, 8), new THREE.MeshLambertMaterial({ color: 0x228B22 }));
-  lv.position.y = 2.3; lv.castShadow = true; g.add(lv);
+  const trunkMat = new THREE.MeshStandardMaterial({ color: 0x6B4226, roughness:0.9 });
+  const leafMat  = new THREE.MeshStandardMaterial({ color: 0x2d8b2d, roughness:0.95 });
+  const tr = new THREE.Mesh(new THREE.CylinderGeometry(0.18*scale, 0.28*scale, 1.8*scale, 8), trunkMat);
+  tr.position.y = 0.9*scale; tr.castShadow = true; g.add(tr);
+  [[1.6*scale, 2.0*scale, 2.1*scale], [1.15*scale, 1.6*scale, 3.1*scale], [0.7*scale, 1.1*scale, 4.0*scale]].forEach(([r, h, y]) => {
+    const lv = new THREE.Mesh(new THREE.ConeGeometry(r, h, 8), leafMat);
+    lv.position.y = y; lv.castShadow = true; g.add(lv);
+  });
   g.position.set(x, 0, z); scene.add(g);
 }
-[-23,23].forEach(x => [-23,0,23].forEach(z => makeTree(x, z)));
+// Trees in corners and mid-edges
+[-24,-18,18,24].forEach(x => [-24,-18,18,24].forEach(z => {
+  if (Math.abs(x)===24 || Math.abs(z)===24) makeTree(x, z, 0.8 + Math.random()*0.5);
+}));
+
+// Hay bales scattered outside fence
+const hayMat = new THREE.MeshStandardMaterial({ color: 0xd4a830, roughness: 0.95 });
+[[22,5],[-22,-8],[12,-24],[-15,20]].forEach(([x,z]) => {
+  const hay = new THREE.Mesh(new THREE.CylinderGeometry(0.6, 0.6, 1.0, 12), hayMat);
+  hay.rotation.z = Math.PI/2; hay.position.set(x, 0.6, z); hay.castShadow = true; scene.add(hay);
+});
+
+// Clouds
+const cloudMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness:1, transparent:true, opacity:0.88 });
+[[0,22,-15],[-12,24,8],[18,20,-5],[-5,26,18]].forEach(([x,y,z]) => {
+  const cg = new THREE.Group();
+  [[0,0,0,1.8],[1.6,0.3,0,1.3],[-1.5,0,0,1.2],[0.8,0.5,1.0,1.0],[-0.7,0.4,-0.9,0.9]].forEach(([cx,cy,cz,r]) => {
+    const sp = new THREE.Mesh(new THREE.SphereGeometry(r, 7, 7), cloudMat);
+    sp.position.set(cx,cy,cz); cg.add(sp);
+  });
+  cg.position.set(x, y, z); cg._isCloud = true; scene.add(cg);
+});
 
 // ═══════════════════════════════════════
 //  GAME DATA
@@ -328,25 +403,40 @@ function buildPlayerMesh() {
   if (playerMesh) scene.remove(playerMesh);
   const sk = SKINS.find(s => s.id === gs.skin) || SKINS[0];
   const g = new THREE.Group();
-  const mk = (geo, color, py) => {
-    const m = new THREE.Mesh(geo, new THREE.MeshLambertMaterial({ color }));
-    m.position.y = py; m.castShadow = true; return m;
+  const mk = (geo, color, py, px=0, pz=0) => {
+    const m = new THREE.Mesh(geo, new THREE.MeshStandardMaterial({ color, roughness:0.75, metalness: color===0xb8b8b8?0.4:0 }));
+    m.position.set(px, py, pz); m.castShadow = true; return m;
   };
-  g.add(mk(new THREE.BoxGeometry(0.8, 1.0, 0.5), sk.body, 0.5));   // body
-  g.add(mk(new THREE.BoxGeometry(0.6, 0.6, 0.6), 0xffcc99, 1.3));  // head
-  g.add(mk(new THREE.CylinderGeometry(0.5, 0.5, 0.07, 12), sk.hat, 1.66)); // brim
-  g.add(mk(new THREE.CylinderGeometry(0.3, 0.3, 0.38, 12), sk.hat, 1.87)); // top
-  [-0.2, 0.2].forEach(x => {
-    const leg = mk(new THREE.BoxGeometry(0.28, 0.5, 0.28), 0x2244aa, 0.0);
-    leg.position.x = x; g.add(leg);
+  // Legs
+  [-0.18, 0.18].forEach(x => {
+    const leg = mk(new THREE.BoxGeometry(0.26, 0.55, 0.26), 0x1a3a88, 0.28); leg.position.x = x; g.add(leg);
+    const boot = mk(new THREE.BoxGeometry(0.28, 0.18, 0.34), 0x2a1a00, 0.0); boot.position.set(x, 0, 0.04); g.add(boot);
   });
-  // weapon
+  // Body / overalls
+  g.add(mk(new THREE.BoxGeometry(0.82, 1.05, 0.48), sk.body, 0.88));
+  // Suspenders
+  g.add(mk(new THREE.BoxGeometry(0.08, 0.6, 0.05), 0xffdd44, 1.05, -0.2, 0.25));
+  g.add(mk(new THREE.BoxGeometry(0.08, 0.6, 0.05), 0xffdd44, 1.05,  0.2, 0.25));
+  // Arms
+  [-0.55, 0.55].forEach(x => {
+    const arm = mk(new THREE.BoxGeometry(0.24, 0.62, 0.24), sk.body, 0.82); arm.position.x = x; g.add(arm);
+    const hand = mk(new THREE.SphereGeometry(0.14, 6, 6), 0xffcc99, 0.52); hand.position.x = x; g.add(hand);
+  });
+  // Head
+  g.add(mk(new THREE.BoxGeometry(0.58, 0.58, 0.58), 0xffcc99, 1.64));
+  // Eyes
+  [-0.13, 0.13].forEach(x => { const ey = mk(new THREE.SphereGeometry(0.07, 5, 5), 0x222222, 1.68); ey.position.set(x, 0, 0.3); g.add(ey); });
+  // Hat brim
+  g.add(mk(new THREE.CylinderGeometry(0.52, 0.52, 0.08, 14), sk.hat, 2.0));
+  // Hat top
+  g.add(mk(new THREE.CylinderGeometry(0.32, 0.36, 0.42, 12), sk.hat, 2.25));
+  // Weapon
   const wid = gs.hotbar[gs.activeSlot];
   if (wid) {
     const wd = WEAPONS.find(w => w.id === wid);
     if (wd) {
-      const wm = mk(new THREE.BoxGeometry(0.18, 0.18, 1.1), wd.color, 0.6);
-      wm.position.x = 0.55; wm.position.z = -0.2; g.add(wm);
+      const wm = mk(new THREE.BoxGeometry(0.16, 0.16, 1.0), wd.color, 0.72, 0.55, -0.1);
+      g.add(wm);
     }
   }
   playerMesh = g;
@@ -494,9 +584,10 @@ function doAttack() {
 }
 
 function spawnProj(pos, dir, spd, data, owner, life) {
+  const col = data.color || 0xffffff;
   const m = new THREE.Mesh(
-    new THREE.SphereGeometry(0.22, 7, 7),
-    new THREE.MeshLambertMaterial({ color: data.color || 0xffffff, emissive: data.color || 0xffffff, emissiveIntensity: 0.4 })
+    new THREE.SphereGeometry(0.26, 8, 8),
+    new THREE.MeshStandardMaterial({ color: col, emissive: col, emissiveIntensity: 0.7, roughness: 0.3, metalness: 0.1 })
   );
   m.position.copy(pos); scene.add(m);
   gs.projectiles.push({ mesh: m, pos: pos.clone(), vel: dir.clone().multiplyScalar(spd), data, owner, timer: life, hitSet: new Set(), bounceLeft: data.bounces || 0 });
@@ -576,11 +667,35 @@ function spawnEnemy(typeId) {
   const pos = new THREE.Vector3(Math.cos(angle) * r, 0, Math.sin(angle) * r);
   const sz = data.sz || 1;
   const g = new THREE.Group();
-  const mk = (geo, col, py) => { const m = new THREE.Mesh(geo, new THREE.MeshLambertMaterial({ color: col })); m.position.y = py; m.castShadow = true; return m; };
-  g.add(mk(new THREE.BoxGeometry(0.5 * sz, 1.4 * sz, 0.3 * sz), data.color, 0.7 * sz));
-  g.add(mk(new THREE.BoxGeometry(1.6 * sz, 0.2 * sz, 0.2 * sz), data.color, 1.1 * sz));
-  g.add(mk(new THREE.BoxGeometry(0.5 * sz, 0.5 * sz, 0.5 * sz), data.id === 'boss' ? 0xff0000 : 0xdd9922, 1.65 * sz));
-  g.add(mk(new THREE.CylinderGeometry(0.15 * sz, 0.25 * sz, 0.4 * sz, 8), 0x2a1a00, 2.0 * sz));
+  const mk = (geo, col, py, px=0, pz=0) => {
+    const m = new THREE.Mesh(geo, new THREE.MeshStandardMaterial({ color: col, roughness:0.9, metalness: col===0x888888?0.3:0 }));
+    m.position.set(px, py, pz); m.castShadow = true; return m;
+  };
+  const isBoss = data.id === 'boss';
+  // Stick body (post)
+  g.add(mk(new THREE.CylinderGeometry(0.1*sz, 0.12*sz, 2.0*sz, 6), 0x8B5E3C, 1.0*sz));
+  // Shirt/body
+  g.add(mk(new THREE.BoxGeometry(0.7*sz, 0.9*sz, 0.35*sz), data.color, 0.95*sz));
+  // Cross arms
+  g.add(mk(new THREE.BoxGeometry(1.7*sz, 0.22*sz, 0.22*sz), data.color, 1.3*sz));
+  g.add(mk(new THREE.BoxGeometry(0.28*sz, 0.55*sz, 0.22*sz), data.color, 0.7*sz, -0.45*sz)); // left cuff
+  g.add(mk(new THREE.BoxGeometry(0.28*sz, 0.55*sz, 0.22*sz), data.color, 0.7*sz,  0.45*sz)); // right cuff
+  // Head (pumpkin head for boss, burlap sack otherwise)
+  const headCol = isBoss ? 0xff4400 : 0xd4a830;
+  g.add(mk(new THREE.SphereGeometry(0.38*sz, 8, 8), headCol, 2.2*sz));
+  // Eyes (glowing)
+  const eyeCol = isBoss ? 0xff0000 : 0x222200;
+  [-0.13*sz, 0.13*sz].forEach(x => { const ey = mk(new THREE.SphereGeometry(0.07*sz, 5, 5), eyeCol, 2.25*sz, x); g.add(ey); });
+  // Hat — wide brim for scarecrow look
+  g.add(mk(new THREE.CylinderGeometry(0.6*sz, 0.6*sz, 0.07*sz, 10), 0x2a1a00, 2.65*sz));
+  g.add(mk(new THREE.CylinderGeometry(0.28*sz, 0.32*sz, 0.5*sz, 8), 0x2a1a00, 2.9*sz));
+  // Straw feet
+  [-0.18*sz, 0.18*sz].forEach(x => { g.add(mk(new THREE.CylinderGeometry(0.08*sz, 0.06*sz, 0.5*sz, 6), 0xd4a830, 0.25*sz, x)); });
+  if (isBoss) {
+    // Boss glowing aura ring
+    const ring = new THREE.Mesh(new THREE.TorusGeometry(0.7*sz, 0.06*sz, 6, 18), new THREE.MeshStandardMaterial({ color: 0xff2200, emissive: 0xff2200, emissiveIntensity: 0.8 }));
+    ring.rotation.x = Math.PI/2; ring.position.y = 0.1; g.add(ring);
+  }
   g.position.copy(pos); scene.add(g);
   const scaledHP = data.hp * (1 + (gs.wave - 1) * 0.1);
   gs.enemies.push({ mesh: g, data, hp: scaledHP, maxHp: scaledHP, pos: pos.clone(), vel: new THREE.Vector3(), attackCd: 0, slowTimer: 0, burnTimer: 0, _dead: false });
@@ -1078,6 +1193,9 @@ function loop(ts) {
     camera.lookAt(gs.playerPos);
     updateHUD();
   }
+
+  // Drift clouds slowly
+  scene.children.forEach(c => { if (c._isCloud) { c.position.x += 0.4 * dt; if (c.position.x > 30) c.position.x = -30; } });
 
   renderer.render(scene, camera);
   requestAnimationFrame(loop);


### PR DESCRIPTION
- Hemisphere light + fill light for richer, more realistic lighting
- Canvas textures on grass ground and dirt farm (random pixel patterns)
- Improved barn: rounded roof, white trim, windows with frames, arch door, chimney
- Full fence with horizontal rails (upper + lower) connecting all posts
- Multi-layer tree canopy (3 stacked cones), more trees around the border
- Hay bales and drifting clouds with animated cloud movement
- Detailed player model: boots, suspenders, eyes, rounded arms, better hat
- Detailed scarecrow model: stick post, cross arms with cuffs, burlap/pumpkin head, straw feet, boss aura ring
- Glowing projectiles using MeshStandardMaterial with emissive colour

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE