### PR TITLE
Make the farm and barn bigger in Garden Farmers

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -129,7 +129,7 @@ scene.background = new THREE.Color(0x87CEEB);
 scene.fog = new THREE.Fog(0x87CEEB, 35, 65);
 
 const camera = new THREE.PerspectiveCamera(50, window.innerWidth / window.innerHeight, 0.1, 100);
-const CAM_OFF = new THREE.Vector3(0, 18, 13);
+const CAM_OFF = new THREE.Vector3(0, 28, 20);
 camera.position.copy(CAM_OFF);
 camera.lookAt(0, 0, 0);
 
@@ -145,8 +145,8 @@ const sun = new THREE.DirectionalLight(0xfff8e0, 1.6);
 sun.position.set(15, 25, 10);
 sun.castShadow = true;
 sun.shadow.mapSize.set(2048, 2048);
-sun.shadow.camera.left = -35; sun.shadow.camera.right = 35;
-sun.shadow.camera.top = 35;  sun.shadow.camera.bottom = -35;
+sun.shadow.camera.left = -55; sun.shadow.camera.right = 55;
+sun.shadow.camera.top = 55;  sun.shadow.camera.bottom = -55;
 sun.shadow.bias = -0.001;
 scene.add(sun);
 const fill = new THREE.DirectionalLight(0x8899ff, 0.35); // cool fill from opposite
@@ -156,7 +156,7 @@ scene.add(fill);
 // ═══════════════════════════════════════
 //  FARM SCENE
 // ═══════════════════════════════════════
-const FARM_R = 18;
+const FARM_R = 28;
 
 // Outer ground — canvas grass texture
 (function() {
@@ -169,7 +169,7 @@ const FARM_R = 18;
     ctx.fillRect(x, y, 3, 3);
   }
   const tex = new THREE.CanvasTexture(c); tex.wrapS = tex.wrapT = THREE.RepeatWrapping; tex.repeat.set(8, 8);
-  const gnd = new THREE.Mesh(new THREE.PlaneGeometry(80, 80), new THREE.MeshStandardMaterial({ map: tex, roughness: 0.95, metalness: 0 }));
+  const gnd = new THREE.Mesh(new THREE.PlaneGeometry(130, 130), new THREE.MeshStandardMaterial({ map: tex, roughness: 0.95, metalness: 0 }));
   gnd.rotation.x = -Math.PI / 2; gnd.receiveShadow = true; scene.add(gnd);
 })();
 
@@ -190,7 +190,7 @@ const FARM_R = 18;
 
 // Fence posts + rails around edge
 const FENCE_MAT = new THREE.MeshStandardMaterial({ color: 0x8B5E3C, roughness: 0.9, metalness: 0 });
-const POST_N = 24;
+const POST_N = 36;
 for (let i = 0; i < POST_N; i++) {
   const a = (i / POST_N) * Math.PI * 2;
   const post = new THREE.Mesh(new THREE.BoxGeometry(0.22, 1.1, 0.22), FENCE_MAT);
@@ -211,30 +211,37 @@ for (let i = 0; i < POST_N; i++) {
 // Barn (center) — improved
 const barnGrp = new THREE.Group();
 const mkBarn = (geo, color, rx=0) => { const m = new THREE.Mesh(geo, new THREE.MeshStandardMaterial({ color, roughness:0.85, metalness:0 })); m.castShadow=true; m.receiveShadow=true; if(rx) m.rotation.y=rx; return m; };
-const barnBody = mkBarn(new THREE.BoxGeometry(5, 3.2, 3.5), 0xc0392b);
-barnBody.position.y = 1.6; barnGrp.add(barnBody);
+const barnBody = mkBarn(new THREE.BoxGeometry(8, 5, 6), 0xc0392b);
+barnBody.position.y = 2.5; barnGrp.add(barnBody);
 // Roof gable
-const barnRoof = mkBarn(new THREE.CylinderGeometry(0.01, 3.8, 2.5, 4), 0x7b3a10, Math.PI/4);
-barnRoof.position.y = 4.45; barnGrp.add(barnRoof);
+const barnRoof = mkBarn(new THREE.CylinderGeometry(0.01, 6, 4, 4), 0x7b3a10, Math.PI/4);
+barnRoof.position.y = 7.0; barnGrp.add(barnRoof);
 // White trim
-const trim = mkBarn(new THREE.BoxGeometry(5.1, 0.18, 3.6), 0xffffff);
-trim.position.y = 3.29; barnGrp.add(trim);
-// Door
-const barnDoor = mkBarn(new THREE.BoxGeometry(1.1, 1.9, 0.12), 0x5C3317);
-barnDoor.position.set(0, 0.95, 1.82); barnGrp.add(barnDoor);
+const trim = mkBarn(new THREE.BoxGeometry(8.2, 0.28, 6.2), 0xffffff);
+trim.position.y = 5.14; barnGrp.add(trim);
+// Door (double doors)
+const barnDoor = mkBarn(new THREE.BoxGeometry(1.8, 3.2, 0.15), 0x5C3317);
+barnDoor.position.set(0, 1.6, 3.08); barnGrp.add(barnDoor);
 // Door arch top
-const arch = mkBarn(new THREE.CylinderGeometry(0.55, 0.55, 0.12, 8, 1, false, 0, Math.PI), 0x5C3317);
-arch.rotation.z = Math.PI/2; arch.position.set(0, 1.9, 1.82); barnGrp.add(arch);
-// Windows
-[-1.6, 1.6].forEach(x => {
-  const win = mkBarn(new THREE.BoxGeometry(0.7, 0.7, 0.1), 0x87ceeb);
-  win.position.set(x, 2.2, 1.82); barnGrp.add(win);
-  const wframe = mkBarn(new THREE.BoxGeometry(0.75, 0.75, 0.06), 0xffffff);
-  wframe.position.set(x, 2.2, 1.86); barnGrp.add(wframe);
+const arch = mkBarn(new THREE.CylinderGeometry(0.9, 0.9, 0.15, 8, 1, false, 0, Math.PI), 0x5C3317);
+arch.rotation.z = Math.PI/2; arch.position.set(0, 3.2, 3.08); barnGrp.add(arch);
+// Windows (4 windows)
+[-2.5, -0.8, 0.8, 2.5].forEach(x => {
+  const win = mkBarn(new THREE.BoxGeometry(1.0, 1.0, 0.12), 0x87ceeb);
+  win.position.set(x, 3.8, 3.09); barnGrp.add(win);
+  const wframe = mkBarn(new THREE.BoxGeometry(1.08, 1.08, 0.08), 0xffffff);
+  wframe.position.set(x, 3.8, 3.12); barnGrp.add(wframe);
 });
-// Chimney
-const chim = mkBarn(new THREE.BoxGeometry(0.4, 1.2, 0.4), 0x884422);
-chim.position.set(1.5, 5.2, 0); barnGrp.add(chim);
+// Side windows
+[-1.0, 1.0].forEach(z => {
+  const win = mkBarn(new THREE.BoxGeometry(0.12, 1.0, 1.0), 0x87ceeb);
+  win.position.set(4.06, 3.5, z); barnGrp.add(win);
+});
+// Chimneys
+[-1.5, 1.5].forEach(x => {
+  const chim = mkBarn(new THREE.BoxGeometry(0.6, 1.8, 0.6), 0x884422);
+  chim.position.set(x, 8.2, 0); barnGrp.add(chim);
+});
 scene.add(barnGrp);
 
 // Barn HP ring
@@ -243,7 +250,7 @@ function updateBarnRing() {
   if (barnRing) scene.remove(barnRing);
   const pct = Math.max(0, gs.barnHP / gs.barnMaxHP);
   const mat = new THREE.MeshBasicMaterial({ color: pct > 0.5 ? 0x4CAF50 : pct > 0.25 ? 0xff9800 : 0xff2222 });
-  barnRing = new THREE.Mesh(new THREE.TorusGeometry(2.5, 0.15, 8, 32, Math.PI * 2 * pct), mat);
+  barnRing = new THREE.Mesh(new THREE.TorusGeometry(4.0, 0.2, 8, 40, Math.PI * 2 * pct), mat);
   barnRing.rotation.x = -Math.PI / 2; barnRing.position.y = 0.05;
   scene.add(barnRing);
 }
@@ -261,14 +268,16 @@ function makeTree(x, z, scale=1) {
   });
   g.position.set(x, 0, z); scene.add(g);
 }
-// Trees in corners and mid-edges
-[-24,-18,18,24].forEach(x => [-24,-18,18,24].forEach(z => {
-  if (Math.abs(x)===24 || Math.abs(z)===24) makeTree(x, z, 0.8 + Math.random()*0.5);
+// Trees in corners and mid-edges (pushed out past the bigger farm)
+[-38,-32,32,38].forEach(x => [-38,-32,32,38].forEach(z => {
+  if (Math.abs(x)===38 || Math.abs(z)===38) makeTree(x, z, 0.8 + Math.random()*0.5);
 }));
+[-35,35].forEach(x => makeTree(x, 0, 1.0 + Math.random()*0.4));
+[0].forEach(x => [-35,35].forEach(z => makeTree(x, z, 1.0 + Math.random()*0.4)));
 
 // Hay bales scattered outside fence
 const hayMat = new THREE.MeshStandardMaterial({ color: 0xd4a830, roughness: 0.95 });
-[[22,5],[-22,-8],[12,-24],[-15,20]].forEach(([x,z]) => {
+[[33,8],[-33,-12],[18,-36],[-22,32],[36,-22],[-30,25]].forEach(([x,z]) => {
   const hay = new THREE.Mesh(new THREE.CylinderGeometry(0.6, 0.6, 1.0, 12), hayMat);
   hay.rotation.z = Math.PI/2; hay.position.set(x, 0.6, z); hay.castShadow = true; scene.add(hay);
 });


### PR DESCRIPTION
Farm:
- FARM_R 18 → 28 (much more open space to defend)
- Fence posts increased 24 → 36 to keep proper spacing
- Ground plane 80 → 130 units wide
- Shadow camera bounds ±35 → ±55
- Camera pulled back to see the bigger area
- Trees and hay bales pushed further out past the new fence line

Barn:
- Body 5×3.2×3.5 → 8×5×6 (roughly 1.6× bigger in all directions)
- Roof radius 3.8 → 6, taller peak
- 4 front windows + 2 side windows instead of 2
- Double-width door with taller arch
- Two chimneys instead of one
- HP ring radius scaled up to match

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE