### PR TITLE
Nerf armored scarecrow — less HP, less armor, less damage

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -392,7 +392,7 @@ const ENEMY_TYPES = [
   { id:'torch',  name:'Torch Scarecrow',        hp:60,  spd:2.5, dmg:8,  straw:10,  sz:1,   color:0xff8c00 },
   { id:'sword',  name:'Sword Scarecrow',        hp:100, spd:1.5, dmg:15, straw:15,  sz:1,   color:0x808080 },
   { id:'flame',  name:'Flamethrower Scarecrow', hp:80,  spd:1.8, dmg:12, straw:20,  sz:1,   color:0xff4500, ranged:true },
-  { id:'armor',  name:'Armored Scarecrow',      hp:200, spd:1.2, dmg:20, straw:30,  sz:1,   color:0x4a4a4a, armor:0.5 },
+  { id:'armor',  name:'Armored Scarecrow',      hp:120, spd:1.2, dmg:14, straw:30,  sz:1,   color:0x4a4a4a, armor:0.25 },
   { id:'boss',   name:'BOSS Scarecrow',         hp:350, spd:1.2, dmg:18, straw:100, sz:1.8, color:0x8b0000 },
 ];
 


### PR DESCRIPTION
hp: 200→120, armor: 0.5→0.25, dmg: 20→14
Effective hit points drop from ~400 to ~160, making them much more manageable.

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE