### PR TITLE
Restore original defense prices — fix double-cost mistake

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -382,13 +382,13 @@ const PLACEABLES = [
 ];
 
 const DEFENSE_ITEMS = [
-  { id:'fence',    name:'Fence',         emoji:'🪵', cost:20, desc:'Slows/blocks enemy path',              type:'fence',    hp:50,  color:0x8b4513 },
-  { id:'campfire', name:'Campfire',      emoji:'🔥', cost:30, desc:'Burns nearby enemies 3/s',             type:'campfire', hp:999, dmg:3,  range:2.5, color:0xff4500 },
-  { id:'moat',     name:'Moat',          emoji:'💧', cost:40, desc:'Slows enemies crossing it',            type:'moat',     hp:999, slow:0.7, color:0x4169e1 },
-  { id:'arrowtwr', name:'Arrow Tower',   emoji:'🏹', cost:50, desc:'Shoots arrows at enemies (range 8)',   type:'arrowtwr', hp:100, dmg:28, range:8,  cd:1.2 },
-  { id:'bombtwr',  name:'Bomb Tower',    emoji:'💣', cost:80, desc:'AoE bomb every 3s (range 5)',          type:'bombtwr',  hp:80,  dmg:60, range:5,  cd:3.0, aoe:3 },
-  { id:'spike',    name:'Spike Trap',    emoji:'🗡️', cost:30, desc:'Damages enemies walking over it',      type:'spike',    hp:80,  dmg:18, range:1.6 },
-  { id:'tesla',    name:'Tesla Coil',    emoji:'⚡', cost:70, desc:'Zaps up to 4 enemies every 2s',        type:'tesla',    hp:70,  dmg:22, range:5.5, cd:2.0, chains:4 },
+  { id:'fence',    name:'Fence',         emoji:'🪵', cost:10, desc:'Slows/blocks enemy path',              type:'fence',    hp:50,  color:0x8b4513 },
+  { id:'campfire', name:'Campfire',      emoji:'🔥', cost:15, desc:'Burns nearby enemies 3/s',             type:'campfire', hp:999, dmg:3,  range:2.5, color:0xff4500 },
+  { id:'moat',     name:'Moat',          emoji:'💧', cost:20, desc:'Slows enemies crossing it',            type:'moat',     hp:999, slow:0.7, color:0x4169e1 },
+  { id:'arrowtwr', name:'Arrow Tower',   emoji:'🏹', cost:25, desc:'Shoots arrows at enemies (range 8)',   type:'arrowtwr', hp:100, dmg:28, range:8,  cd:1.2 },
+  { id:'bombtwr',  name:'Bomb Tower',    emoji:'💣', cost:40, desc:'AoE bomb every 3s (range 5)',          type:'bombtwr',  hp:80,  dmg:60, range:5,  cd:3.0, aoe:3 },
+  { id:'spike',    name:'Spike Trap',    emoji:'🗡️', cost:15, desc:'Damages enemies walking over it',      type:'spike',    hp:80,  dmg:18, range:1.6 },
+  { id:'tesla',    name:'Tesla Coil',    emoji:'⚡', cost:35, desc:'Zaps up to 4 enemies every 2s',        type:'tesla',    hp:70,  dmg:22, range:5.5, cd:2.0, chains:4 },
 ];
 
 const ENEMY_TYPES = [


### PR DESCRIPTION
When the double-charge bug was reported I accidentally doubled all the prices instead of fixing the code. The double-charge in placeAtMouse was already removed in the previous commit. This reverts the prices back to their correct values (fence 10, campfire 15, moat 20, arrow tower 25, bomb tower 40, spike 15, tesla 35).

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE