### PR TITLE
Make scene darker — night/dusk atmosphere

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -143,21 +143,21 @@ renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 renderer.toneMapping = THREE.ACESFilmicToneMapping;
-renderer.toneMappingExposure = 0.5;
+renderer.toneMappingExposure = 0.32;
 renderer.outputEncoding = THREE.sRGBEncoding;
 
 const scene = new THREE.Scene();
-scene.fog = new THREE.FogExp2(0x9ecfe8, 0.008);
+scene.fog = new THREE.FogExp2(0x3a5a78, 0.01);
 
 // Sky gradient dome
 (function() {
   const c = document.createElement('canvas'); c.width = 2; c.height = 256;
   const ctx = c.getContext('2d');
   const g = ctx.createLinearGradient(0, 0, 0, 256);
-  g.addColorStop(0,    '#0d4fa8');
-  g.addColorStop(0.45, '#3a8de8');
-  g.addColorStop(0.75, '#7fc8f5');
-  g.addColorStop(1,    '#c8e8f8');
+  g.addColorStop(0,    '#060e22');
+  g.addColorStop(0.45, '#0d2a55');
+  g.addColorStop(0.75, '#1a3d6e');
+  g.addColorStop(1,    '#2a5080');
   ctx.fillStyle = g; ctx.fillRect(0, 0, 2, 256);
   const tex = new THREE.CanvasTexture(c);
   const sky = new THREE.Mesh(
@@ -179,8 +179,8 @@ window.addEventListener('resize', () => {
 });
 
 // Lighting
-scene.add(new THREE.HemisphereLight(0xb0e0ff, 0x4a7a00, 0.25));
-const sun = new THREE.DirectionalLight(0xfff8e0, 0.7);
+scene.add(new THREE.HemisphereLight(0x223355, 0x1a2a00, 0.12));
+const sun = new THREE.DirectionalLight(0xaab8d0, 0.38);
 sun.position.set(15, 25, 10);
 sun.castShadow = true;
 sun.shadow.mapSize.set(2048, 2048);
@@ -188,10 +188,10 @@ sun.shadow.camera.left = -75; sun.shadow.camera.right = 75;
 sun.shadow.camera.top = 75;  sun.shadow.camera.bottom = -75;
 sun.shadow.bias = -0.001;
 scene.add(sun);
-const fill = new THREE.DirectionalLight(0x8899ff, 0.18);
+const fill = new THREE.DirectionalLight(0x334466, 0.1);
 fill.position.set(-10, 8, -10);
 scene.add(fill);
-const rimLight = new THREE.DirectionalLight(0xffeedd, 0.22);
+const rimLight = new THREE.DirectionalLight(0x998877, 0.12);
 rimLight.position.set(-8, 6, 18);
 scene.add(rimLight);
 
@@ -291,10 +291,10 @@ arch.rotation.z = Math.PI/2; arch.position.set(0, 3.2, 3.08); barnGrp.add(arch);
 });
 scene.add(barnGrp);
 // Warm glow from barn windows
-const barnLight = new THREE.PointLight(0xffaa44, 2.5, 18);
+const barnLight = new THREE.PointLight(0xff8822, 3.5, 20);
 barnLight.position.set(0, 3.5, 3.5);
 scene.add(barnLight);
-const barnLight2 = new THREE.PointLight(0xffaa44, 1.2, 12);
+const barnLight2 = new THREE.PointLight(0xff7711, 1.8, 14);
 barnLight2.position.set(0, 3.5, -3.5);
 scene.add(barnLight2);
 


### PR DESCRIPTION
- toneMappingExposure: 0.5 → 0.32
- Sky gradient: bright blue day → deep dark navy night
- Fog: light blue → dark blue-grey, slightly denser
- HemisphereLight: 0.25 → 0.12, tinted dark blue/green
- Sun: 0.7 → 0.38, cooler moonlight colour
- Fill + rim lights: significantly dimmed
- Barn lights: boosted intensity so they glow warmly against the dark

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE