### PR TITLE
Animals roam the whole farm instead of staying near placement spot

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -2779,11 +2779,10 @@ function updatePlacedPlants(dt) {
       }
     }
 
-    // Animal movement — wander around home position
+    // Animal movement — roam the whole farm
     if (p.data.kind === 'animal') {
-      if (!p._home) {
-        p._home = p.pos.clone();
-        p._vel  = new THREE.Vector3();
+      if (!p._vel) {
+        p._vel = new THREE.Vector3();
         p._wanderTimer = Math.random() * 2;
         p._bobPhase = Math.random() * Math.PI * 2;
       }
@@ -2798,10 +2797,12 @@ function updatePlacedPlants(dt) {
           p._vel.set(Math.cos(angle) * spd, 0, Math.sin(angle) * spd);
         }
       }
-      // Drift back if too far from home
-      if (p.pos.distanceTo(p._home) > 5.5) {
-        const hd = p._home.clone().sub(p.pos).normalize();
-        p._vel.x = hd.x * 2.8; p._vel.z = hd.z * 2.8;
+      // Steer away from farm boundary
+      const distFromCenter = Math.hypot(p.pos.x, p.pos.z);
+      if (distFromCenter > FARM_R - 3) {
+        const inward = new THREE.Vector3(-p.pos.x, 0, -p.pos.z).normalize();
+        p._vel.x = inward.x * 2.8; p._vel.z = inward.z * 2.8;
+        p._wanderTimer = 0.5;
       }
       p.pos.x += p._vel.x * dt;
       p.pos.z += p._vel.z * dt;


### PR DESCRIPTION
Removed home-position tether — animals now wander freely across the entire farm. They steer inward when within 3 units of the boundary and pick a new direction, so they naturally bounce around the whole area.

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE