### PR TITLE
Fix save reliability, flying bird speed

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -3222,10 +3222,10 @@ function updatePlacedPlants(dt) {
           p._homePos = p.pos.clone();
           p._orbitAngle = Math.random() * Math.PI * 2;
           p._orbitDir = Math.random() < 0.5 ? 1 : -1;
-          p._orbitR = 1.8 + Math.random() * 1.4;
+          p._orbitR = 2.5 + Math.random() * 2.0;
           p._flyH = 2.2 + Math.random() * 0.8;
         }
-        p._orbitAngle += p._orbitDir * 0.9 * dt;
+        p._orbitAngle += p._orbitDir * 2.4 * dt;
         p._bobPhase += dt * 3.0;
         const nx = p._homePos.x + Math.cos(p._orbitAngle) * p._orbitR;
         const nz = p._homePos.z + Math.sin(p._orbitAngle) * p._orbitR;
@@ -3472,7 +3472,7 @@ function spawnWildBird() {
   const orbitDir = Math.random() < 0.5 ? 1 : -1;
   gs.wildBirds.push({
     mesh, pos: mesh.position.clone(),
-    orbitAngle: angle, orbitR: r, orbitSpd: (0.3 + Math.random() * 0.4) * orbitDir,
+    orbitAngle: angle, orbitR: r, orbitSpd: (0.7 + Math.random() * 0.8) * orbitDir,
     height, bobPhase: Math.random() * Math.PI * 2,
     life: 25 + Math.random() * 35, maxLife: 60,
   });
@@ -4036,6 +4036,7 @@ function loadAndPlay() {
   stopTheme();
   startBattleTheme();
   loadGame();
+  applyBiomeTheme(gs.biome);
   document.getElementById('screen').classList.add('hidden');
   gameStarted = true;
   buildPlayerMesh(); buildHotbar(); updateHUD();
@@ -4055,15 +4056,24 @@ const SAVE_KEY = 'gardenFarmers_v1';
 function hasSave() { return !!localStorage.getItem(SAVE_KEY); }
 
 function saveGame() {
-  localStorage.setItem(SAVE_KEY, JSON.stringify({
-    straw: gs.straw, wave: gs.wave, skin: gs.skin, biome: gs.biome,
-    barnHP: gs.barnHP, barnMaxHP: gs.barnMaxHP, barnCannons: gs.barnCannons,
-    playerHP: gs.playerHP, totalKills: gs.totalKills,
-    ownedWeapons: [...gs.ownedWeapons], ownedPlaceables: [...gs.ownedPlaceables],
-    hotbar: gs.hotbar, farmExpansions: gs.farmExpansions,
-    placedPlants: gs.placedPlants.map(p => ({ id: p.data.id, x: p.pos.x, z: p.pos.z, hp: p.hp })),
-    defenses: gs.defenses.map(d => ({ id: d.data.id, x: d.pos.x, z: d.pos.z })),
-  }));
+  try {
+    const data = {
+      straw: gs.straw, wave: gs.wave, skin: gs.skin, biome: gs.biome,
+      barnHP: gs.barnHP, barnMaxHP: gs.barnMaxHP, barnCannons: gs.barnCannons,
+      playerHP: gs.playerHP, totalKills: gs.totalKills,
+      ownedWeapons: [...gs.ownedWeapons], ownedPlaceables: [...gs.ownedPlaceables],
+      hotbar: gs.hotbar, farmExpansions: gs.farmExpansions,
+      placedPlants: gs.placedPlants
+        .filter(p => p && p.data && p.pos)
+        .map(p => ({ id: p.data.id, x: +(p._homePos || p.pos).x.toFixed(3), z: +(p._homePos || p.pos).z.toFixed(3), hp: p.hp })),
+      defenses: gs.defenses
+        .filter(d => d && d.data && d.pos)
+        .map(d => ({ id: d.data.id, x: +d.pos.x.toFixed(3), z: +d.pos.z.toFixed(3) })),
+    };
+    localStorage.setItem(SAVE_KEY, JSON.stringify(data));
+  } catch (err) {
+    console.error('saveGame failed:', err);
+  }
 }
 
 function loadGame() {


### PR DESCRIPTION
- saveGame now wrapped in try-catch so failures are visible in console
- saveGame filters out any null/corrupt entries before serializing
- saveGame uses _homePos for flying birds (saves placement center, not orbit pos)
- loadAndPlay now calls applyBiomeTheme so correct biome is applied on load
- Placed flying birds orbit 2.7x faster (2.4 rad/s vs 0.9) with larger radius
- Wild birds orbit ~2x faster (0.7-1.5 rad/s vs 0.3-0.7)

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE