### PR TITLE
Fix army never reaching enemy base to attack

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -4836,7 +4836,7 @@ function updateArmy(dt) {
   // Advance formation center if fewer than half are in combat
   if (gs.activeArmy.length > 0 && combatCount < gs.activeArmy.length * 0.5) {
     gs._formationCenter.z -= FORM_SPD * dt;
-    gs._formationCenter.z = Math.max(BASE_Z + 14, gs._formationCenter.z);
+    gs._formationCenter.z = Math.max(BASE_Z + 2, gs._formationCenter.z);
   }
 
   gs.activeArmy = gs.activeArmy.filter(u => {


### PR DESCRIPTION
Formation center was clamped at BASE_Z+14 (-81) but the base-strike trigger requires unit.pos.z < BASE_Z+10 (-85), so units stalled 4 units short and never hit. Lowered clamp to BASE_Z+2 (-93) so the formation advances deep enough for all rows to reach the strike zone.

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE