### PR TITLE
Increase all scarecrow movement speeds by ~40%

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -971,21 +971,20 @@ const RANDOM_EVENTS = [
 ];
 
 const ENEMY_TYPES = [
-  { id:'basic',  name:'Basic Scarecrow',        hp:40,  spd:2.0, dmg:5,  straw:5,   sz:1,   color:0xd2b48c },
-  { id:'torch',  name:'Torch Scarecrow',        hp:60,  spd:2.5, dmg:8,  straw:10,  sz:1,   color:0xff8c00 },
-  { id:'sword',  name:'Sword Scarecrow',        hp:100, spd:1.5, dmg:15, straw:15,  sz:1,   color:0x808080 },
-  { id:'flame',  name:'Flamethrower Scarecrow', hp:80,  spd:1.8, dmg:12, straw:20,  sz:1,   color:0xff4500, ranged:true },
-  { id:'armor',  name:'Armored Scarecrow',      hp:120, spd:1.2, dmg:14, straw:30,  sz:1,   color:0x4a4a4a, armor:0.25 },
-  { id:'boss',   name:'BOSS Scarecrow',         hp:350, spd:1.2, dmg:18, straw:100, sz:1.8, color:0x8b0000 },
-  // New scarecrows
-  { id:'speedy', name:'Speed Demon',            hp:28,  spd:5.5, dmg:5,  straw:8,   sz:0.85,color:0xffee00 },
-  { id:'bomb',   name:'Bomb Scarecrow',         hp:90,  spd:1.6, dmg:14, straw:22,  sz:1.1, color:0x2a2a2a },
-  { id:'ice',    name:'Ice Scarecrow',          hp:75,  spd:1.5, dmg:9,  straw:18,  sz:1,   color:0x88ccff, ranged:true },
-  { id:'shadow', name:'Shadow Scarecrow',       hp:65,  spd:3.0, dmg:12, straw:20,  sz:0.9, color:0x440088 },
-  { id:'giant',  name:'Giant Scarecrow',        hp:700, spd:0.65,dmg:28, straw:120, sz:2.6, color:0x5c3d1e },
-  { id:'mage',   name:'Magician Scarecrow',     hp:90,  spd:2.0, dmg:14, straw:28,  sz:1,   color:0x6600cc, ranged:true, teleport:true },
-  { id:'golden', name:'Golden Scarecrow',       hp:260, spd:0.85,dmg:15, straw:200, sz:1.25,color:0xFFD700 },
-  { id:'guard',  name:'Guard Scarecrow',        hp:120, spd:1.9, dmg:13, straw:8,   sz:1.05,color:0x5c3000 },
+  { id:'basic',  name:'Basic Scarecrow',        hp:40,  spd:2.9, dmg:5,  straw:5,   sz:1,   color:0xd2b48c },
+  { id:'torch',  name:'Torch Scarecrow',        hp:60,  spd:3.5, dmg:8,  straw:10,  sz:1,   color:0xff8c00 },
+  { id:'sword',  name:'Sword Scarecrow',        hp:100, spd:2.2, dmg:15, straw:15,  sz:1,   color:0x808080 },
+  { id:'flame',  name:'Flamethrower Scarecrow', hp:80,  spd:2.6, dmg:12, straw:20,  sz:1,   color:0xff4500, ranged:true },
+  { id:'armor',  name:'Armored Scarecrow',      hp:120, spd:1.8, dmg:14, straw:30,  sz:1,   color:0x4a4a4a, armor:0.25 },
+  { id:'boss',   name:'BOSS Scarecrow',         hp:350, spd:1.8, dmg:18, straw:100, sz:1.8, color:0x8b0000 },
+  { id:'speedy', name:'Speed Demon',            hp:28,  spd:8.0, dmg:5,  straw:8,   sz:0.85,color:0xffee00 },
+  { id:'bomb',   name:'Bomb Scarecrow',         hp:90,  spd:2.3, dmg:14, straw:22,  sz:1.1, color:0x2a2a2a },
+  { id:'ice',    name:'Ice Scarecrow',          hp:75,  spd:2.2, dmg:9,  straw:18,  sz:1,   color:0x88ccff, ranged:true },
+  { id:'shadow', name:'Shadow Scarecrow',       hp:65,  spd:4.4, dmg:12, straw:20,  sz:0.9, color:0x440088 },
+  { id:'giant',  name:'Giant Scarecrow',        hp:700, spd:1.0, dmg:28, straw:120, sz:2.6, color:0x5c3d1e },
+  { id:'mage',   name:'Magician Scarecrow',     hp:90,  spd:2.9, dmg:14, straw:28,  sz:1,   color:0x6600cc, ranged:true, teleport:true },
+  { id:'golden', name:'Golden Scarecrow',       hp:260, spd:1.3, dmg:15, straw:200, sz:1.25,color:0xFFD700 },
+  { id:'guard',  name:'Guard Scarecrow',        hp:120, spd:2.8, dmg:13, straw:8,   sz:1.05,color:0x5c3000 },
 ];
 
 const WAVES = [


### PR DESCRIPTION
basic 2.0→2.9, torch 2.5→3.5, sword 1.5→2.2, flame 1.8→2.6, armor 1.2→1.8, boss 1.2→1.8, speedy 5.5→8.0, bomb 1.6→2.3, ice 1.5→2.2, shadow 3.0→4.4, giant 0.65→1.0, mage 2.0→2.9, golden 0.85→1.3, guard 1.9→2.8

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE