### PR TITLE
Security audit fixes: CSP headers, hardcoded IDs, workflow pinning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/checkout@v4
     
     - name: Run security scan
-      uses: github/super-linter@v4
+      uses: github/super-linter@v7
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         VALIDATE_ALL_CODEBASE: false

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -8,23 +8,23 @@ jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
-    
+
     steps:
     - name: Dependabot metadata
       id: metadata
-      uses: dependabot/fetch-metadata@v1
+      uses: dependabot/fetch-metadata@v2
       with:
         github-token: "${{ secrets.GITHUB_TOKEN }}"
-        
-    - name: Enable auto-merge for Dependabot PRs
-      if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
-      run: gh pr merge --auto --merge "$PR_URL"
+
+    - name: Enable auto-merge for patch-only Dependabot PRs
+      if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+      run: gh pr merge --auto --squash "$PR_URL"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
-    - name: Approve Dependabot PRs
-      if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+
+    - name: Approve patch-only Dependabot PRs
+      if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
       run: gh pr review --approve "$PR_URL"
       env:
         PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,7 +114,7 @@ jobs:
           HEAD > release-assets/titanblade-games-source-${{ steps.vars.outputs.version }}.zip
           
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         tag_name: ${{ steps.vars.outputs.version }}
         name: Titanblade Games ${{ steps.vars.outputs.version }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,15 +27,15 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3
 
   dependency-review:
     name: Dependency Review
@@ -47,7 +47,7 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Dependency Review
-      uses: actions/dependency-review-action@v3
+      uses: actions/dependency-review-action@v4
       
   secret-scan:
     name: Secret Scanning
@@ -58,9 +58,9 @@ jobs:
       uses: actions/checkout@v4
       
     - name: Run TruffleHog OSS
-      uses: trufflesecurity/trufflehog@main
+      uses: trufflesecurity/trufflehog@v3.88.27
       with:
         path: ./
         base: main
         head: HEAD
-        extra_args: --debug --only-verified
+        extra_args: --only-verified

--- a/battle-of-the-druids/index.html
+++ b/battle-of-the-druids/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes, shrink-to-fit=no, viewport-fit=cover">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://cdn.jsdelivr.net https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io; worker-src blob:; frame-ancestors 'none';">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
     <title>Battle of the Druids - Free Online RPG Game</title>
     <meta name="description" content="Play Battle of the Druids - A free turn-based RPG with 4 character classes, tactical combat, equipment progression, and 9 unique locations. Play instantly in your browser!">
     <meta name="keywords" content="free online rpg, browser game, turn-based combat, fantasy rpg, character classes, online game">
@@ -13,7 +17,7 @@
     <meta property="og:type" content="website">
     <meta property="og:title" content="Battle of the Druids - Free Online RPG">
     <meta property="og:description" content="Epic turn-based RPG with character classes, magical spells, and tactical combat. Play free in your browser!">
-    <meta property="og:url" content="http://battle-of-the-druids-web.s3-website-ap-southeast-2.amazonaws.com/">
+    <meta property="og:url" content="https://www.titanbladegames.com/battle-of-the-druids/">
     
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
@@ -192,14 +196,14 @@
             integrations: [
                 Sentry.browserTracingIntegration(),
                 Sentry.replayIntegration({
-                    maskAllText: false,
-                    blockAllMedia: false,
+                    maskAllText: true,
+                    blockAllMedia: true,
                 }),
             ],
             environment: "production",
             release: "battle-of-the-druids@1.0.0",
-            tracesSampleRate: 1.0,
-            replaysSessionSampleRate: 0.1,
+            tracesSampleRate: 0.1,
+            replaysSessionSampleRate: 0.05,
             replaysOnErrorSampleRate: 1.0,
         });
         

--- a/battle-of-the-druids/js/Game.js
+++ b/battle-of-the-druids/js/Game.js
@@ -147,16 +147,22 @@ window.addEventListener('load', () => {
         
         const gameContainer = document.getElementById('game-container');
         if (gameContainer) {
-            gameContainer.innerHTML = `
-                <div style="color: white; text-align: center; padding: 50px;">
-                    <h2>Game Initialization Failed</h2>
-                    <p>Error: ${error.message}</p>
-                    <p style="font-size: 12px;">Check console for details</p>
-                    <button onclick="location.reload()" style="padding: 10px 20px; font-size: 16px;">
-                        Try Again
-                    </button>
-                </div>
-            `;
+            const wrapper = document.createElement('div');
+            wrapper.style.cssText = 'color: white; text-align: center; padding: 50px;';
+            const heading = document.createElement('h2');
+            heading.textContent = 'Game Initialization Failed';
+            const msg = document.createElement('p');
+            msg.textContent = `Error: ${error.message}`;
+            const hint = document.createElement('p');
+            hint.style.fontSize = '12px';
+            hint.textContent = 'Check console for details';
+            const btn = document.createElement('button');
+            btn.style.cssText = 'padding: 10px 20px; font-size: 16px;';
+            btn.textContent = 'Try Again';
+            btn.addEventListener('click', () => location.reload());
+            wrapper.append(heading, msg, hint, btn);
+            gameContainer.textContent = '';
+            gameContainer.appendChild(wrapper);
         }
     }
 });

--- a/bombs_at_sea/index.html
+++ b/bombs_at_sea/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self'; frame-ancestors 'none';">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
     <title>Bombs At Sea</title>
     <link rel="stylesheet" href="style.css">
 </head>

--- a/doom-riders/index.html
+++ b/doom-riders/index.html
@@ -5,6 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0, minimum-scale=0.5, user-scalable=yes, shrink-to-fit=no, viewport-fit=cover">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self'; worker-src blob:; frame-ancestors 'none';">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
     <title>Doom Riders - TitanBlade Games</title>
     <style>
         body {

--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -3,6 +3,10 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self'; worker-src blob:; frame-ancestors 'none';">
+<meta http-equiv="X-Content-Type-Options" content="nosniff">
+<meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+<meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
 <title>Garden Farmers - Titan Blade Games</title>
 <style>
 * { margin:0; padding:0; box-sizing:border-box; }

--- a/index.html
+++ b/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; img-src 'self' data:; media-src 'self'; connect-src https://www.google-analytics.com https://analytics.google.com; frame-ancestors 'none';">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
     <title>TitanBlade Games - Open Source Game Studio</title>
     <meta name="description" content="TitanBlade Games - Open source RPGs, adventure games, racing games, and strategy games. Play Battle of the Druids, Isle of Adventure, Doom Riders, Bombs at Sea and contribute to our MIT-licensed game projects.">
     <meta name="keywords" content="open source games, indie games, rpg games, racing games, strategy games, naval warfare, browser games, TitanBlade Games, Battle of the Druids, Doom Riders, Isle of Adventure, Bombs at Sea, MIT license, free games">

--- a/isle-of-adventure/index.html
+++ b/isle-of-adventure/index.html
@@ -5,15 +5,19 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=3.0, user-scalable=yes, shrink-to-fit=no, viewport-fit=cover">
     <meta name="mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://www.google-analytics.com https://cdn.jsdelivr.net https://browser.sentry-cdn.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https://www.google-analytics.com https://analytics.google.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io; worker-src blob:; frame-ancestors 'none';">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
     <title>Isle of Adventure</title>
     
     <!-- Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-ELX1WWLJN8"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{GOOGLE_ANALYTICS_ID}}"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
         function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
-        gtag('config', 'G-ELX1WWLJN8', {
+        gtag('config', '{{GOOGLE_ANALYTICS_ID}}', {
             page_title: 'Isle of Adventure',
             custom_map: {'custom_parameter': 'game_events'}
         });
@@ -139,14 +143,14 @@
             integrations: [
                 Sentry.browserTracingIntegration(),
                 Sentry.replayIntegration({
-                    maskAllText: false,
-                    blockAllMedia: false,
+                    maskAllText: true,
+                    blockAllMedia: true,
                 }),
             ],
             environment: "production",
             release: "isle-of-adventure@1.0.0",
-            tracesSampleRate: 1.0,
-            replaysSessionSampleRate: 0.1,
+            tracesSampleRate: 0.1,
+            replaysSessionSampleRate: 0.05,
             replaysOnErrorSampleRate: 1.0,
         });
         

--- a/stick-wars/index.html
+++ b/stick-wars/index.html
@@ -3,6 +3,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' stun:stun.l.google.com:19302; worker-src blob:; frame-ancestors 'none';">
+    <meta http-equiv="X-Content-Type-Options" content="nosniff">
+    <meta http-equiv="Referrer-Policy" content="strict-origin-when-cross-origin">
+    <meta http-equiv="Permissions-Policy" content="camera=(), microphone=(), geolocation=()">
     <title>Stick Wars</title>
     <style>
         body {


### PR DESCRIPTION
- Add Content-Security-Policy, X-Content-Type-Options, Referrer-Policy,
  and Permissions-Policy meta tags to all six game pages and main index
- Fix hardcoded Google Analytics ID (G-ELX1WWLJN8) in isle-of-adventure;
  replace with {{GOOGLE_ANALYTICS_ID}} placeholder like other pages
- Fix Sentry session replay privacy: maskAllText/blockAllMedia → true,
  tracesSampleRate 1.0 → 0.1, replaysSessionSampleRate 0.1 → 0.05
- Fix XSS risk in battle-of-the-druids Game.js: replace innerHTML injection
  of error.message with safe DOM API (textContent + createElement)
- Upgrade CodeQL actions v2 → v3 in security.yml
- Pin TruffleHog to v3.88.27 (was @main branch ref)
- Upgrade dependency-review-action v3 → v4
- Upgrade softprops/action-gh-release v1 → v2 in release.yml
- Upgrade super-linter v4 → v7 in ci.yml
- Restrict Dependabot auto-merge to patch-only (not minor) updates;
  upgrade fetch-metadata v1 → v2
- Fix HTTP og:url in battle-of-the-druids to HTTPS canonical URL

https://claude.ai/code/session_013TcjQ6rqWujT9iMECrxjQg