### PR TITLE
Overhaul Stick Wars: fix critical combat bugs, rebalance, and polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Stick Wars - Major Overhaul
+
+#### Fixed
+- Melee attacks dealt damage every frame of the swing animation (~20x intended damage); each swing now lands once at the moment of impact
+- A scoping bug (`const Combat = window.Combat || ...`) crashed the frame whenever a projectile or explosion hit, skipping game logic and suppressing all hit effects
+- Enemy ranged attacks fired backwards (away from their target) due to a facing-direction mismatch with `Object3D.lookAt`
+- Player movement used an inverted rotation, so WASD drifted in the wrong direction at most camera angles; first-person mode ignored facing entirely
+- Enemy health bars never faced the camera (looked at the ambient light instead)
+- Weapon key 7 did nothing despite the "Press 7 to equip" message; keyboard weapon switching now also syncs the weapon-bar highlight
+- Player death removed the camera from the scene and the game kept running; there is now a proper game-over state that freezes the battle
+- Damage flash could get stuck leaving figures permanently red when hits overlapped
+- Bomb unlock threshold was inconsistent (20 vs 200 coins); unlocks are now 100 coins (rifle) and 150 coins (bomb) with progress shown in the HUD
+- Enemies could spawn on top of the player; they now spawn in a ring around the player and avoid obstacles
+- Mobile attack button was unreachable (covered by the look-touch area) and now supports hold-to-attack
+- Local 2P passed a color where a character type was expected, player 2's controls never registered, and player 2's attacks damaged player 1; all fixed, and player 2 is tinted blue
+- Removed the non-functional online multiplayer buttons (connection handshake could never complete)
+
+#### Changed
+- Full combat rebalance: player 200 HP, enemy HP 50-140 by type, sensible weapon damage/cooldown tradeoffs, gentler wave scaling
+- Smarter AI: melee types charge with type-specific weapons, archers/mages keep distance and kite, enemies slide around obstacles and no longer stack on one spot
+- Player projectiles follow the camera pitch so you can aim up and down
+
+#### Added
+- Procedural sound effects (Web Audio): attacks, hits, coins, explosions, reloads, wave start, unlocks, victory/defeat
+- Visual HUD health bar, damage vignette when hurt, reload indicator, named weapon slots with lock state
+- Pause (P key), hold-to-attack on desktop and mobile, coin magnet pickup, richer wave/victory/defeat screens with run stats
+
 ### Added
 - Comprehensive issue templates for bug reports, feature requests, and questions
 - Enhanced GitHub Actions workflows for CI/CD, security, and automation

--- a/stick-wars/index.html
+++ b/stick-wars/index.html
@@ -36,6 +36,50 @@
             padding: 10px;
             border-radius: 5px;
             margin-bottom: 10px;
+            line-height: 1.6;
+        }
+
+        #healthBarOuter {
+            display: inline-block;
+            width: 150px;
+            height: 14px;
+            background: #333;
+            border: 1px solid #555;
+            border-radius: 7px;
+            overflow: hidden;
+            vertical-align: middle;
+            margin: 0 6px;
+        }
+
+        #healthBarInner {
+            width: 100%;
+            height: 100%;
+            background: #4CAF50;
+            transition: width 0.2s, background 0.2s;
+        }
+
+        #damageOverlay {
+            position: absolute;
+            inset: 0;
+            pointer-events: none;
+            background: radial-gradient(ellipse at center, transparent 55%, rgba(255,0,0,0.6) 100%);
+            opacity: 0;
+            transition: opacity 0.35s;
+            z-index: 90;
+        }
+
+        #pauseOverlay {
+            position: absolute;
+            inset: 0;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            background: rgba(0,0,0,0.6);
+            color: white;
+            font-size: 42px;
+            font-weight: bold;
+            z-index: 800;
+            text-align: center;
         }
 
         #multiplayerMenu {
@@ -97,6 +141,7 @@
             width: 150px;
             height: 150px;
             pointer-events: auto;
+            z-index: 20;
         }
 
         #joystick-base {
@@ -121,7 +166,7 @@
             transition: all 0.1s;
         }
 
-        /* Attack Button */
+        /* Attack Button (z-index keeps it above the look area) */
         #attack-button {
             position: absolute;
             bottom: 20px;
@@ -138,6 +183,7 @@
             pointer-events: auto;
             user-select: none;
             -webkit-tap-highlight-color: transparent;
+            z-index: 20;
         }
 
         #attack-button:active {
@@ -154,6 +200,7 @@
             height: 100%;
             pointer-events: auto;
             touch-action: none;
+            z-index: 10;
         }
 
         /* Mobile UI adjustments */
@@ -165,14 +212,18 @@
             }
 
             .weapon-slot {
-                width: 40px;
-                height: 40px;
-                font-size: 14px;
+                width: 44px;
+                height: 44px;
+                font-size: 13px;
             }
 
             #gameInfo {
                 font-size: 12px;
                 padding: 8px;
+            }
+
+            #healthBarOuter {
+                width: 90px;
             }
 
             #multiplayerMenu {
@@ -186,20 +237,29 @@
             right: 10px;
             display: flex;
             gap: 10px;
+            z-index: 30;
         }
 
         .weapon-slot {
-            width: 50px;
-            height: 50px;
+            width: 54px;
+            height: 54px;
             background: rgba(0,0,0,0.7);
             border: 2px solid #666;
             border-radius: 5px;
             display: flex;
+            flex-direction: column;
             align-items: center;
             justify-content: center;
             color: white;
             font-weight: bold;
             cursor: pointer;
+        }
+
+        .weapon-slot small {
+            font-size: 9px;
+            font-weight: normal;
+            color: #ccc;
+            margin-top: 2px;
         }
 
         .weapon-slot.active {
@@ -243,55 +303,59 @@
             <div class="crosshair-line crosshair-v"></div>
         </div>
 
+        <div id="damageOverlay"></div>
+        <div id="pauseOverlay">PAUSED<br><span style="font-size: 20px; font-weight: normal;">Press P to resume</span></div>
+
         <div id="ui">
             <div id="gameInfo">
-                <div>Health: <span id="healthValue">3000</span>/3000</div>
+                <div>❤️<span id="healthBarOuter"><span id="healthBarInner"></span></span><span id="healthValue">200/200</span></div>
                 <div>Weapon: <span id="currentWeapon">Sword</span></div>
                 <div>Wave: <span id="waveNumber">1/5</span></div>
                 <div>Enemies: <span id="enemyCount">5</span></div>
-                <div>Coins: <span id="coinCount">0</span></div>
+                <div>🪙 <span id="coinCount">0</span><span id="coinGoal" style="color:#aaa;"></span></div>
             </div>
         </div>
 
         <div id="multiplayerMenu">
             <h4>Multiplayer</h4>
             <button onclick="startLocalMultiplayer()">Local 2P</button>
-            <button onclick="createOnlineGame()">Create Online</button>
-            <button onclick="joinOnlineGame()">Join Online</button>
         </div>
 
         <div id="weaponBar">
             <div class="weapon-slot active" data-weapon="0" onclick="switchWeapon(0)">
-                <span>1</span>
+                <span>1</span><small>Sword</small>
             </div>
             <div class="weapon-slot" data-weapon="1" onclick="switchWeapon(1)">
-                <span>2</span>
+                <span>2</span><small>Axe</small>
             </div>
             <div class="weapon-slot" data-weapon="2" onclick="switchWeapon(2)">
-                <span>3</span>
+                <span>3</span><small>Spear</small>
             </div>
             <div class="weapon-slot" data-weapon="3" onclick="switchWeapon(3)">
-                <span>4</span>
+                <span>4</span><small>Hammer</small>
             </div>
             <div class="weapon-slot" data-weapon="4" onclick="switchWeapon(4)">
-                <span>5</span>
+                <span>5</span><small>Crossbow</small>
             </div>
-            <div class="weapon-slot" data-weapon="5" onclick="switchWeapon(5)" style="opacity: 0.3;">
-                <span>6</span>
+            <div class="weapon-slot" data-weapon="5" onclick="switchWeapon(5)" style="opacity: 0.4;">
+                <span>6</span><small>Rifle 🔒</small>
             </div>
-            <div class="weapon-slot" data-weapon="6" onclick="switchWeapon(6)" style="opacity: 0.3;">
-                <span>7</span>
+            <div class="weapon-slot" data-weapon="6" onclick="switchWeapon(6)" style="opacity: 0.4;">
+                <span>7</span><small>Bomb 🔒</small>
             </div>
         </div>
 
         <div id="controls">
             <strong>Controls:</strong><br>
-            WASD: Move | Mouse: Look Around | Click: Attack<br>
-            1-7: Switch Weapons | R: Reload | C: Toggle Camera | ESC: Release mouse
+            WASD: Move | Mouse: Look | Hold Click: Attack<br>
+            1-7: Weapons | R: Reload | C: Camera | P: Pause | ESC: Release mouse
         </div>
 
         <!-- Mobile Touch Controls -->
         <div class="mobile-controls">
+            <!-- Look/Aim Touch Area (below the buttons) -->
+            <div id="look-area"></div>
+
             <!-- Virtual Joystick -->
             <div id="joystick-container">
                 <div id="joystick-base"></div>
@@ -300,13 +364,11 @@
 
             <!-- Attack Button -->
             <div id="attack-button">⚔️</div>
-
-            <!-- Look/Aim Touch Area -->
-            <div id="look-area"></div>
         </div>
     </div>
 
     <script src="js/libs/three.min.js"></script>
+    <script src="js/stickman-wars/Sound.js"></script>
     <script src="js/stickman-wars/Environment.js"></script>
     <script src="js/stickman-wars/Arrow.js"></script>
     <script src="js/stickman-wars/Bomb.js"></script>
@@ -340,7 +402,8 @@
                 lastY: 0
             },
             attack: {
-                active: false
+                active: false,
+                interval: null
             }
         };
 
@@ -352,7 +415,6 @@
             const lookArea = document.getElementById('look-area');
 
             if (!joystickContainer || !attackButton || !lookArea) {
-                console.log('Touch controls not found (probably desktop)');
                 return;
             }
 
@@ -461,7 +523,7 @@
                 touchControls.look.lastY = touch.clientY;
 
                 // Apply camera rotation (similar to mouse move)
-                if (game && game.currentPlayer) {
+                if (game && game.currentPlayer && !game.paused) {
                     const sensitivity = 0.003;
 
                     if (game.cameraMode === 'third') {
@@ -486,34 +548,37 @@
                 touchControls.look.active = false;
             });
 
-            // Attack Button
+            // Attack Button - hold to keep attacking (weapon cooldowns limit the rate)
+            const tryAttack = () => {
+                if (game && game.currentPlayer && !game.paused && !game.gameOver && !game.gameWon) {
+                    game.currentPlayer.attack(game);
+                }
+            };
+
             attackButton.addEventListener('touchstart', (e) => {
                 e.preventDefault();
                 touchControls.attack.active = true;
+                tryAttack();
 
-                if (game && game.currentPlayer) {
-                    game.currentPlayer.attack(game);
-                }
+                clearInterval(touchControls.attack.interval);
+                touchControls.attack.interval = setInterval(tryAttack, 150);
             });
 
             attackButton.addEventListener('touchend', (e) => {
                 e.preventDefault();
                 touchControls.attack.active = false;
+                clearInterval(touchControls.attack.interval);
+                touchControls.attack.interval = null;
             });
-
-            console.log('Touch controls initialized');
         }
 
         // Initialize the game
         function initGame() {
             try {
-                console.log('Initializing game...');
                 game = new Game3D();
                 game.init();
-                console.log('Game initialized successfully');
 
                 multiplayerManager = new MultiplayerManager(game);
-                console.log('Multiplayer manager initialized');
 
                 // Initialize touch controls for mobile devices
                 initTouchControls();
@@ -536,12 +601,6 @@
         function switchWeapon(index) {
             if (game && game.currentPlayer) {
                 game.currentPlayer.switchWeapon(index);
-
-                // Update UI
-                document.querySelectorAll('.weapon-slot').forEach(slot => {
-                    slot.classList.remove('active');
-                });
-                document.querySelector(`[data-weapon="${index}"]`).classList.add('active');
             }
         }
 
@@ -553,31 +612,20 @@
 
         // Multiplayer Functions
         function startLocalMultiplayer() {
+            if (!multiplayerManager || multiplayerManager.localMultiplayerEnabled) return;
             multiplayerManager.enableLocalMultiplayer();
 
             // Update UI to show both players
             const gameInfo = document.getElementById('gameInfo');
-            gameInfo.innerHTML += '<div style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #666;">Player 2 Controls: Arrow Keys + NumPad</div>';
+            gameInfo.innerHTML += '<div style="margin-top: 10px; padding-top: 10px; border-top: 1px solid #666;">Player 2: Arrow Keys move, NumPad 0 attack, NumPad 1-4 weapons</div>';
         }
 
-        function createOnlineGame() {
-            multiplayerManager.createOnlineGame();
-        }
-
-        function joinOnlineGame() {
-            const offerString = prompt('Paste the connection string from the host:');
-            if (offerString) {
-                multiplayerManager.joinOnlineGame(offerString);
-            }
-        }
-
-        // Game loop additions
+        // Game loop additions (UI only - game logic lives in Game3D.animate)
         function gameUpdate() {
             if (game) {
                 updateEnemyCount();
 
-                // Check lose condition only (victory is handled by wave system in Game3D.js)
-                if (game.currentPlayer && game.currentPlayer.health <= 0) {
+                if (game.gameOver) {
                     showDefeatMessage();
                 }
             }
@@ -590,6 +638,10 @@
         function showDefeatMessage() {
             if (gameOverShown) return;
             gameOverShown = true;
+
+            if (document.pointerLockElement) {
+                document.exitPointerLock();
+            }
 
             const message = document.createElement('div');
             message.style.position = 'absolute';
@@ -610,7 +662,7 @@
             message.appendChild(title);
 
             const text = document.createElement('p');
-            text.textContent = 'Better luck next time!';
+            text.textContent = `You made it to wave ${game ? game.currentWave : '?'} of ${game ? game.maxWaves : '?'}. Better luck next time!`;
             text.style.margin = '0 0 20px 0';
             message.appendChild(text);
 

--- a/stick-wars/js/stickman-wars/Arrow.js
+++ b/stick-wars/js/stickman-wars/Arrow.js
@@ -2,12 +2,14 @@ class Arrow {
     constructor(scene, startPos, direction, owner) {
         this.scene = scene;
         this.owner = owner;
-        this.speed = 20;
-        // Use the owner's current weapon damage
+        // Use the owner's current weapon damage; rifles fire faster, flatter shots
+        const weaponName = owner.currentWeapon ? owner.currentWeapon.name : '';
+        this.speed = weaponName === 'Rifle' ? 45 : 22;
+        this.gravity = weaponName === 'Rifle' ? 0.05 : 0.3;
         this.damage = owner.currentWeapon ? owner.currentWeapon.damage : 10;
         this.alive = true;
         this.distanceTraveled = 0;
-        this.maxDistance = 50;
+        this.maxDistance = weaponName === 'Rifle' ? 80 : 50;
 
         // Create arrow mesh
         this.group = new THREE.Group();
@@ -65,7 +67,7 @@ class Arrow {
         this.distanceTraveled += movement.length();
 
         // Add gravity effect (slower for more accurate shots)
-        this.direction.y -= 0.3 * deltaTime;
+        this.direction.y -= this.gravity * deltaTime;
 
         // Update arrow rotation to match trajectory
         const horizontalDistance = Math.sqrt(this.direction.x * this.direction.x + this.direction.z * this.direction.z);
@@ -95,8 +97,6 @@ class Arrow {
 
             // More forgiving hitbox - 1.2 unit horizontal radius
             if (horizontalDist < 1.2 && validHeight) {
-                // Hit!
-                console.log('Arrow hit target!', 'Distance:', horizontalDist, 'Height:', arrowHeight, 'Damage:', this.damage);
                 this.alive = false;
                 this.remove();
                 return { target, damage: this.damage };

--- a/stick-wars/js/stickman-wars/Bomb.js
+++ b/stick-wars/js/stickman-wars/Bomb.js
@@ -53,9 +53,8 @@ class Bomb {
         this.group.position.copy(startPos);
         this.group.position.y += 1.5; // Throw from chest height
 
-        // Set direction (bombs arc through the air)
+        // Set direction (the thrower already added the upward arc)
         this.direction = direction.normalize();
-        this.direction.y += 0.3; // Initial upward arc
 
         this.scene.add(this.group);
 
@@ -102,7 +101,7 @@ class Bomb {
         this.hasExploded = true;
         this.alive = false;
 
-        console.log('💣 BOMB EXPLODING at position:', this.group.position);
+        if (window.Sound) window.Sound.explosion();
 
         // Create explosion effect
         this.createExplosion();
@@ -252,7 +251,6 @@ class Bomb {
 
             // If bomb hits target directly, explode
             if (horizontalDist < 1.0 && validHeight) {
-                console.log('💥 Bomb hit target directly! Exploding...');
                 this.explode();
                 return { target, damage: this.damage, isExplosion: true };
             }
@@ -275,13 +273,10 @@ class Bomb {
             const dz = this.group.position.z - target.group.position.z;
             const distance = Math.sqrt(dx * dx + dz * dz);
 
-            // If within explosion radius, apply damage
+            // If within explosion radius, apply damage with distance falloff
             if (distance < this.explosionRadius) {
-                // Damage falls off with distance
                 const damageMultiplier = 1 - (distance / this.explosionRadius);
-                const explosionDamage = Math.floor(this.damage * damageMultiplier);
-
-                console.log(`💥 Explosion hit ${target.characterType} at distance ${distance.toFixed(2)}, damage: ${explosionDamage}`);
+                const explosionDamage = Math.max(1, Math.floor(this.damage * damageMultiplier));
 
                 hitTargets.push({ target, damage: explosionDamage });
             }

--- a/stick-wars/js/stickman-wars/Combat.js
+++ b/stick-wars/js/stickman-wars/Combat.js
@@ -1,16 +1,11 @@
 class Combat {
-    static calculateDamage(attacker, target, weapon) {
-        let baseDamage = weapon.damage;
+    static calculateDamage(attacker, weapon) {
+        // Weapon damage scaled by the attacker's multiplier (character type +
+        // wave scaling), with a little randomness
+        const baseDamage = weapon.damage * (attacker.damageMultiplier || 1);
+        const randomFactor = 0.85 + Math.random() * 0.3; // 85% to 115% damage
 
-        // Enemies deal fixed 100 damage
-        if (!attacker.isPlayer) {
-            baseDamage = 100;
-        }
-
-        // Add some randomness
-        const randomFactor = 0.8 + Math.random() * 0.4; // 80% to 120% damage
-
-        return Math.floor(baseDamage * randomFactor);
+        return Math.max(1, Math.floor(baseDamage * randomFactor));
     }
 
     static isInRange(attacker, target, weapon) {
@@ -162,7 +157,7 @@ class Combat {
 
         targets.forEach(target => {
             if (target.health > 0 && this.isInRange(attacker, target, attacker.currentWeapon)) {
-                const damage = this.calculateDamage(attacker, target, attacker.currentWeapon);
+                const damage = this.calculateDamage(attacker, attacker.currentWeapon);
 
                 target.takeDamage(damage);
 

--- a/stick-wars/js/stickman-wars/Game3D.js
+++ b/stick-wars/js/stickman-wars/Game3D.js
@@ -4,10 +4,9 @@ class Game3D {
         this.camera = null;
         this.renderer = null;
         this.players = [];
-        this.weapons = [];
         this.keys = {};
-        this.mouse = { x: 0, y: 0 };
         this.isPointerLocked = false;
+        this.isMouseDown = false;
         this.cameraMode = 'third'; // 'first' or 'third'
 
         this.currentPlayer = null;
@@ -17,7 +16,8 @@ class Game3D {
         this.arrows = [];
         this.bombs = []; // Thrown bombs
         this.coins = []; // Collectible coins dropped by enemies
-        this.playerCoins = 0; // Total coins collected
+        this.playerCoins = 0; // Coins currently held
+        this.totalCoinsEarned = 0; // Lifetime coins (for the victory screen)
         this.environment = null;
 
         this.clock = new THREE.Clock();
@@ -36,14 +36,14 @@ class Game3D {
         this.waveInProgress = false;
         this.waveCompleteTimer = 0;
         this.gameWon = false;
+        this.gameOver = false;
+        this.paused = false;
 
-        // Bind methods
+        // Weapon unlock costs (auto-purchased when affordable)
+        this.rifleCost = 100;
+        this.bombCost = 150;
+
         this.animate = this.animate.bind(this);
-        this.onKeyDown = this.onKeyDown.bind(this);
-        this.onKeyUp = this.onKeyUp.bind(this);
-        this.onMouseMove = this.onMouseMove.bind(this);
-        this.onMouseClick = this.onMouseClick.bind(this);
-        this.onPointerLockChange = this.onPointerLockChange.bind(this);
     }
 
     init() {
@@ -58,12 +58,13 @@ class Game3D {
         this.createPlayer();
         this.createNeutralTanks();
         this.startWave(1);
+        this.updateCoinUI();
 
         this.animate();
     }
 
     createNeutralTanks() {
-        // Create 1-2 powerful neutral tanks that attack everyone
+        // Powerful neutral tanks that attack everyone - defeat one to convert it to your side
         const tankCount = 2;
 
         for (let i = 0; i < tankCount; i++) {
@@ -81,12 +82,9 @@ class Game3D {
 
             this.neutralTanks.push(neutralTank);
 
-            // AI will be updated in updateEnemyAI
-            neutralTank.aiTarget = null; // Will find nearest target
+            neutralTank.aiTarget = null;
             neutralTank.aiUpdateTimer = Math.random() * 2;
         }
-
-        console.log(`Spawned ${tankCount} neutral tanks`);
     }
 
     setupScene() {
@@ -155,11 +153,14 @@ class Game3D {
     }
 
     setupControls() {
-        document.addEventListener('keydown', this.onKeyDown);
-        document.addEventListener('keyup', this.onKeyUp);
-        document.addEventListener('mousemove', this.onMouseMove);
-        document.addEventListener('click', this.onMouseClick);
-        document.addEventListener('pointerlockchange', this.onPointerLockChange);
+        // Wrappers (instead of bound references) so MultiplayerManager can override
+        // the handlers at runtime and the listeners pick up the new versions.
+        document.addEventListener('keydown', (e) => this.onKeyDown(e));
+        document.addEventListener('keyup', (e) => this.onKeyUp(e));
+        document.addEventListener('mousemove', (e) => this.onMouseMove(e));
+        document.addEventListener('mousedown', (e) => this.onMouseDown(e));
+        document.addEventListener('mouseup', (e) => this.onMouseUp(e));
+        document.addEventListener('pointerlockchange', () => this.onPointerLockChange());
 
         // Request pointer lock on first click (only on non-touch devices)
         const isTouchDevice = ('ontouchstart' in window) || (navigator.maxTouchPoints > 0);
@@ -176,12 +177,10 @@ class Game3D {
     onKeyDown(event) {
         this.keys[event.code] = true;
 
-        // Weapon switching (1-6)
-        if (event.code >= 'Digit1' && event.code <= 'Digit6') {
-            const weaponIndex = parseInt(event.code.charAt(5)) - 1;
-            if (this.currentPlayer) {
-                this.currentPlayer.switchWeapon(weaponIndex);
-            }
+        // Weapon switching (1-7)
+        const digitMatch = /^Digit([1-7])$/.exec(event.code);
+        if (digitMatch && this.currentPlayer) {
+            this.currentPlayer.switchWeapon(parseInt(digitMatch[1]) - 1);
         }
 
         // Camera mode toggle with C key
@@ -190,10 +189,13 @@ class Game3D {
         }
 
         // Reload with R key
-        if (event.code === 'KeyR') {
-            if (this.currentPlayer) {
-                this.currentPlayer.reloadWeapon();
-            }
+        if (event.code === 'KeyR' && this.currentPlayer) {
+            this.currentPlayer.reloadWeapon();
+        }
+
+        // Pause with P key
+        if (event.code === 'KeyP') {
+            this.togglePause();
         }
     }
 
@@ -202,7 +204,7 @@ class Game3D {
     }
 
     onMouseMove(event) {
-        if (this.isPointerLocked && this.currentPlayer) {
+        if (this.isPointerLocked && this.currentPlayer && !this.paused) {
             const sensitivity = 0.002;
 
             if (this.cameraMode === 'third') {
@@ -222,14 +224,31 @@ class Game3D {
         }
     }
 
-    onMouseClick(event) {
-        if (this.isPointerLocked && this.currentPlayer) {
+    onMouseDown(event) {
+        if (event.button !== 0) return;
+        this.isMouseDown = true;
+        if (this.isPointerLocked && this.currentPlayer && !this.paused && !this.gameOver && !this.gameWon) {
             this.currentPlayer.attack(this);
+        }
+    }
+
+    onMouseUp(event) {
+        if (event.button === 0) {
+            this.isMouseDown = false;
         }
     }
 
     onPointerLockChange() {
         this.isPointerLocked = document.pointerLockElement === this.renderer.domElement;
+    }
+
+    togglePause() {
+        if (this.gameOver || this.gameWon) return;
+        this.paused = !this.paused;
+        const overlay = document.getElementById('pauseOverlay');
+        if (overlay) {
+            overlay.style.display = this.paused ? 'flex' : 'none';
+        }
     }
 
     createPlayer() {
@@ -243,47 +262,70 @@ class Game3D {
     }
 
     startWave(waveNumber) {
-        console.log(`Starting wave ${waveNumber}`);
+        if (this.gameOver || this.gameWon) return;
+
         this.currentWave = waveNumber;
         this.waveInProgress = true;
 
-        // Restore player health to full
+        // Drop dead enemies from the list so it doesn't grow forever
+        this.enemies = this.enemies.filter(e => e.health > 0);
+
+        // Restore player health to full between waves
         if (this.currentPlayer) {
             this.currentPlayer.health = this.currentPlayer.maxHealth;
-            document.getElementById('healthValue').textContent = this.currentPlayer.health;
-            console.log(`Player health restored to ${this.currentPlayer.health}`);
+            this.currentPlayer.updateHealthUI();
         }
 
         // Update UI
         document.getElementById('waveNumber').textContent = `${waveNumber}/${this.maxWaves}`;
 
-        // Show wave start message
-        this.showWaveMessage(`Wave ${waveNumber} Starting!`);
+        const enemyCount = this.createEnemies(waveNumber);
 
-        // Create enemies for this wave
-        this.createEnemies(waveNumber);
-
-        console.log(`Wave ${waveNumber} started with ${this.enemies.filter(e => e.health > 0).length} enemies`);
+        this.showWaveMessage(`Wave ${waveNumber} Starting!`, `Health restored • ${enemyCount} enemies incoming`);
+        if (window.Sound) window.Sound.waveStart();
     }
 
     createEnemies(waveNumber) {
-        // Create diverse enemy types
         const enemyTypes = ['rogue', 'mage', 'tank', 'archer', 'warrior'];
+
+        // Starting weapon per enemy type (melee types charge, ranged types kite)
+        const weaponByType = {
+            rogue: 0,        // sword
+            warrior: 1,      // axe
+            tank: 3,         // hammer
+            skateboarder: 2, // spear (fast drive-by attacker)
+            archer: 4,       // crossbow
+            mage: 4          // crossbow
+        };
 
         // More enemies each wave (3 + 2 per wave)
         const enemyCount = 3 + (waveNumber * 2);
 
         // Enemy scaling per wave
-        const healthMultiplier = 1 + (waveNumber - 1) * 0.3; // +30% health per wave
-        const damageMultiplier = 1 + (waveNumber - 1) * 0.25; // +25% damage per wave
+        const healthMultiplier = 1 + (waveNumber - 1) * 0.15;
+        const damageMultiplier = 1 + (waveNumber - 1) * 0.10;
 
-        // First enemy is ALWAYS a skateboarder (fast enemy)
+        // Fast skateboarders show up more often in later waves
+        const skateboarderCount = Math.min(3, 1 + Math.floor((waveNumber - 1) / 2));
+
+        const playerPos = this.currentPlayer ? this.currentPlayer.group.position : new THREE.Vector3();
+
         for (let i = 0; i < enemyCount; i++) {
-            const x = (Math.random() - 0.5) * 30;
-            const z = (Math.random() - 0.5) * 30;
+            // Spawn in a ring around the player so nothing pops in on top of them
+            let x = 0, z = 0, attempts = 0;
+            do {
+                const angle = Math.random() * Math.PI * 2;
+                const radius = 15 + Math.random() * 12;
+                x = playerPos.x + Math.cos(angle) * radius;
+                z = playerPos.z + Math.sin(angle) * radius;
+                x = Math.max(this.mapBoundary.minX, Math.min(this.mapBoundary.maxX, x));
+                z = Math.max(this.mapBoundary.minZ, Math.min(this.mapBoundary.maxZ, z));
+                attempts++;
+            } while (this.environment.checkCollision(new THREE.Vector3(x, 0, z), 1) && attempts < 10);
 
-            // First enemy is skateboarder, rest are normal types
-            const enemyType = i === 0 ? 'skateboarder' : enemyTypes[i % enemyTypes.length];
+            const enemyType = i < skateboarderCount
+                ? 'skateboarder'
+                : enemyTypes[(i - skateboarderCount) % enemyTypes.length];
 
             const enemy = new StickFigure(this.scene, x, 0, z, enemyType, false);
 
@@ -292,46 +334,38 @@ class Game3D {
             enemy.health = enemy.maxHealth;
             enemy.damageMultiplier *= damageMultiplier;
 
-            this.enemies.push(enemy);
-
-            // Give enemies simple AI - initially target player
             enemy.aiTarget = this.currentPlayer;
             enemy.aiUpdateTimer = Math.random() * 2; // Randomize update timing
+            enemy.prefersRanged = (enemyType === 'archer' || enemyType === 'mage');
+            enemy.switchWeapon(weaponByType[enemyType] !== undefined ? weaponByType[enemyType] : 0);
 
-            // Archers and mages start with pistol equipped
-            if (enemyType === 'archer' || enemyType === 'mage') {
-                enemy.switchWeapon(4); // Pistol is weapon index 4
-            }
+            this.enemies.push(enemy);
         }
 
-        console.log(`Wave ${waveNumber} enemies: ${enemyCount} total (1 skateboarder!), Health x${healthMultiplier.toFixed(2)}, Damage x${damageMultiplier.toFixed(2)}`);
+        return enemyCount;
     }
 
     createCoin(position, offsetX = 0, offsetZ = 0) {
         // Create a spinning golden coin
         const coinGroup = new THREE.Group();
 
-        // Coin cylinder (flat disc) - slightly bigger for visibility
         const coinGeometry = new THREE.CylinderGeometry(0.2, 0.2, 0.06, 16);
         const coinMaterial = new THREE.MeshLambertMaterial({ color: 0xFFD700, emissive: 0x886600 });
         const coin = new THREE.Mesh(coinGeometry, coinMaterial);
         coin.castShadow = true;
         coinGroup.add(coin);
 
-        // Add a rim for detail
         const rimGeometry = new THREE.TorusGeometry(0.2, 0.03, 8, 16);
         const rimMaterial = new THREE.MeshLambertMaterial({ color: 0xFFA500 });
         const rim = new THREE.Mesh(rimGeometry, rimMaterial);
         rim.rotation.x = Math.PI / 2;
         coinGroup.add(rim);
 
-        // Position coin slightly above ground with offset
         coinGroup.position.copy(position);
         coinGroup.position.x += offsetX;
         coinGroup.position.z += offsetZ;
         coinGroup.position.y = 0.4;
 
-        // Store coin data
         const coinData = {
             group: coinGroup,
             rotation: 0,
@@ -341,30 +375,22 @@ class Game3D {
 
         this.scene.add(coinGroup);
         this.coins.push(coinData);
-
-        console.log(`Coin created at: x=${coinGroup.position.x.toFixed(2)}, y=${coinGroup.position.y.toFixed(2)}, z=${coinGroup.position.z.toFixed(2)}`);
     }
 
     checkDeadEnemies() {
         // Check for dead enemies and spawn coins
         this.enemies.forEach(enemy => {
             if (enemy.health <= 0 && enemy.deathPosition && !enemy.coinDropped) {
-                // Mark that we've dropped coins for this enemy
                 enemy.coinDropped = true;
 
                 // Drop 5-10 coins per enemy
                 const numCoins = 5 + Math.floor(Math.random() * 6);
 
-                console.log(`Enemy died at position:`, enemy.deathPosition, `dropping ${numCoins} coins`);
-
-                // Spread coins in a wider circle around death position
+                // Spread coins in a circle around the death position
                 for (let i = 0; i < numCoins; i++) {
                     const angle = (Math.PI * 2 * i) / numCoins + (Math.random() - 0.5) * 0.5;
-                    const radius = 0.8 + Math.random() * 0.8; // Increased scatter radius
-                    const offsetX = Math.cos(angle) * radius;
-                    const offsetZ = Math.sin(angle) * radius;
-
-                    this.createCoin(enemy.deathPosition, offsetX, offsetZ);
+                    const radius = 0.8 + Math.random() * 0.8;
+                    this.createCoin(enemy.deathPosition, Math.cos(angle) * radius, Math.sin(angle) * radius);
                 }
             }
         });
@@ -375,37 +401,39 @@ class Game3D {
         for (let i = this.neutralTanks.length - 1; i >= 0; i--) {
             const tank = this.neutralTanks[i];
             if (tank.isAlly) {
-                // Remove from neutral tanks and add to allies
                 this.neutralTanks.splice(i, 1);
                 this.allyTanks.push(tank);
-                console.log('Tank converted! Now have', this.allyTanks.length, 'ally tanks');
             }
         }
     }
 
     checkWaveComplete() {
-        if (!this.waveInProgress || this.gameWon) return;
+        if (!this.waveInProgress || this.gameWon || this.gameOver) return;
 
-        // Count alive enemies
         const aliveEnemies = this.enemies.filter(enemy => enemy.health > 0).length;
 
         if (aliveEnemies === 0) {
-            console.log(`Wave ${this.currentWave} complete! Starting wave ${this.currentWave + 1} in 3 seconds...`);
             this.waveInProgress = false;
             this.waveCompleteTimer = 3; // 3 second delay before next wave
 
             if (this.currentWave >= this.maxWaves) {
-                // Game won!
                 this.gameWon = true;
                 this.showVictoryMessage();
+                if (window.Sound) window.Sound.victory();
             } else {
-                // Show wave complete message
-                this.showWaveMessage(`Wave ${this.currentWave} Complete! Next wave in 3 seconds...`);
+                this.showWaveMessage(`Wave ${this.currentWave} Complete!`, 'Next wave in 3 seconds...');
             }
         }
     }
 
-    showWaveMessage(message) {
+    checkPlayerDefeat() {
+        if (!this.gameOver && this.currentPlayer && this.currentPlayer.health <= 0) {
+            this.gameOver = true;
+            if (window.Sound) window.Sound.defeat();
+        }
+    }
+
+    showWaveMessage(message, subMessage = '') {
         // Remove old message if exists
         const oldMessage = document.getElementById('waveMessage');
         if (oldMessage) oldMessage.remove();
@@ -427,9 +455,18 @@ class Game3D {
         messageDiv.style.border = '3px solid #FFD700';
         messageDiv.textContent = message;
 
+        if (subMessage) {
+            const sub = document.createElement('div');
+            sub.textContent = subMessage;
+            sub.style.fontSize = '18px';
+            sub.style.color = '#FFFFFF';
+            sub.style.marginTop = '8px';
+            sub.style.fontWeight = 'normal';
+            messageDiv.appendChild(sub);
+        }
+
         document.body.appendChild(messageDiv);
 
-        // Remove after 3 seconds
         setTimeout(() => {
             if (messageDiv.parentNode) {
                 messageDiv.parentNode.removeChild(messageDiv);
@@ -465,8 +502,14 @@ class Game3D {
 
         const text = document.createElement('p');
         text.textContent = `All ${this.maxWaves} waves defeated!`;
-        text.style.margin = '0 0 30px 0';
+        text.style.margin = '0 0 10px 0';
         messageDiv.appendChild(text);
+
+        const stats = document.createElement('p');
+        stats.textContent = `🪙 Coins collected: ${this.totalCoinsEarned}`;
+        stats.style.margin = '0 0 30px 0';
+        stats.style.fontSize = '24px';
+        messageDiv.appendChild(stats);
 
         const button = document.createElement('button');
         button.textContent = 'Play Again';
@@ -482,10 +525,14 @@ class Game3D {
         messageDiv.appendChild(button);
 
         document.body.appendChild(messageDiv);
+
+        if (document.pointerLockElement) {
+            document.exitPointerLock();
+        }
     }
 
     updatePlayer(deltaTime) {
-        if (!this.currentPlayer) return;
+        if (!this.currentPlayer || this.currentPlayer.health <= 0) return;
 
         const moveSpeed = 5 * deltaTime;
         const direction = new THREE.Vector3();
@@ -495,139 +542,78 @@ class Game3D {
         if (this.keys['KeyA']) direction.x -= 1;
         if (this.keys['KeyD']) direction.x += 1;
 
-        if (direction.length() > 0) {
-            direction.normalize();
+        if (direction.length() === 0) return;
 
-            // Apply player rotation to movement direction
-            if (this.cameraMode === 'third') {
-                const playerRotation = this.currentPlayer.group.rotation.y;
-                const rotatedDirection = new THREE.Vector3(
-                    direction.x * Math.cos(playerRotation) - direction.z * Math.sin(playerRotation),
-                    0,
-                    direction.x * Math.sin(playerRotation) + direction.z * Math.cos(playerRotation)
-                );
-                direction.copy(rotatedDirection);
+        direction.normalize();
+
+        // Rotate the input by the player's facing so W always moves forward
+        direction.applyAxisAngle(new THREE.Vector3(0, 1, 0), this.currentPlayer.group.rotation.y);
+
+        const pos = this.currentPlayer.group.position;
+        const tryStep = (dx, dz) => {
+            const nx = Math.max(this.mapBoundary.minX, Math.min(this.mapBoundary.maxX, pos.x + dx));
+            const nz = Math.max(this.mapBoundary.minZ, Math.min(this.mapBoundary.maxZ, pos.z + dz));
+            if (!this.environment.checkCollision(new THREE.Vector3(nx, 0, nz), 0.5)) {
+                this.currentPlayer.move(nx - pos.x, nz - pos.z);
+                return true;
             }
+            return false;
+        };
 
-            // Calculate new position
-            const newPosition = this.currentPlayer.group.position.clone();
-            newPosition.x += direction.x * moveSpeed;
-            newPosition.z += direction.z * moveSpeed;
-
-            // Clamp position to map boundaries
-            newPosition.x = Math.max(this.mapBoundary.minX, Math.min(this.mapBoundary.maxX, newPosition.x));
-            newPosition.z = Math.max(this.mapBoundary.minZ, Math.min(this.mapBoundary.maxZ, newPosition.z));
-
-            // Check for environment collisions
-            if (!this.environment.checkCollision(newPosition, 0.5)) {
-                // Calculate the actual movement delta after boundary clamping
-                const deltaX = newPosition.x - this.currentPlayer.group.position.x;
-                const deltaZ = newPosition.z - this.currentPlayer.group.position.z;
-                this.currentPlayer.move(deltaX, deltaZ);
+        // Try the full move first, then slide along each axis if blocked
+        const stepX = direction.x * moveSpeed;
+        const stepZ = direction.z * moveSpeed;
+        if (!tryStep(stepX, stepZ)) {
+            if (!tryStep(stepX, 0)) {
+                tryStep(0, stepZ);
             }
         }
     }
 
-    updateAllyTanks(deltaTime) {
-        this.allyTanks.forEach(tank => {
-            if (tank.health <= 0) return;
-
-            // Update AI target timer
-            tank.aiUpdateTimer -= deltaTime;
-            if (tank.aiUpdateTimer <= 0) {
-                // Re-evaluate target every 2-3 seconds
-                tank.aiUpdateTimer = 2 + Math.random();
-                tank.aiTarget = this.chooseAllyTarget(tank);
-            }
-
-            if (tank.aiTarget && tank.aiTarget.health > 0) {
-                const targetPos = tank.aiTarget.group.position;
-                const tankPos = tank.group.position;
-
-                const direction = new THREE.Vector3()
-                    .subVectors(targetPos, tankPos)
-                    .normalize();
-
-                const distance = tankPos.distanceTo(targetPos);
-
-                // Get weapon range for attack distance
-                const attackRange = tank.currentWeapon ? tank.currentWeapon.range : 2.0;
-                const minDistance = attackRange * 0.8;
-
-                if (distance > minDistance) {
-                    // Move towards target
-                    tank.move(direction.x * deltaTime * 2, direction.z * deltaTime * 2);
-
-                    // Clamp to map boundaries
-                    this.clampToMapBoundaries(tank);
-                } else if (distance <= attackRange) {
-                    // Attack if within weapon range
-                    if (Math.random() < 0.03) { // Slightly higher attack chance
-                        tank.attack(this);
-                    }
-                }
-
-                // Face the target
-                tank.group.lookAt(targetPos.x, tankPos.y, targetPos.z);
-            }
-        });
+    // Which characters this attacker is allowed to damage
+    getTargetsFor(owner) {
+        const alivePlayers = this.players.filter(p => p.health > 0);
+        if (owner.isNeutral) {
+            // Neutral tanks attack everyone except other neutral tanks
+            return [...alivePlayers, ...this.enemies, ...this.neutralTanks.filter(t => t !== owner), ...this.allyTanks];
+        }
+        if (owner.isAlly) {
+            // Ally tanks only attack enemies
+            return [...this.enemies];
+        }
+        if (this.players.includes(owner)) {
+            // Players hit enemies and neutral tanks (not ally tanks)
+            return [...this.enemies, ...this.neutralTanks];
+        }
+        // Enemies work together - they hit players, neutral tanks and ally tanks
+        return [...alivePlayers, ...this.neutralTanks, ...this.allyTanks];
     }
 
-    updateNeutralTanks(deltaTime) {
-        this.neutralTanks.forEach(tank => {
-            if (tank.health <= 0) return;
+    chooseTarget(char) {
+        let potentialTargets;
+        const alivePlayers = this.players.filter(p => p.health > 0);
 
-            // Update AI target timer
-            tank.aiUpdateTimer -= deltaTime;
-            if (tank.aiUpdateTimer <= 0) {
-                // Re-evaluate target every 2-3 seconds
-                tank.aiUpdateTimer = 2 + Math.random();
-                tank.aiTarget = this.chooseNeutralTarget(tank);
-            }
+        if (char.isAlly) {
+            potentialTargets = this.enemies.filter(e => e.health > 0);
+        } else if (char.isNeutral) {
+            potentialTargets = [
+                ...alivePlayers,
+                ...this.enemies.filter(e => e.health > 0),
+                ...this.neutralTanks.filter(t => t !== char && t.health > 0)
+            ];
+        } else {
+            potentialTargets = [
+                ...alivePlayers,
+                ...this.neutralTanks.filter(t => t.health > 0),
+                ...this.allyTanks.filter(t => t.health > 0)
+            ];
+        }
 
-            if (tank.aiTarget && tank.aiTarget.health > 0) {
-                const targetPos = tank.aiTarget.group.position;
-                const tankPos = tank.group.position;
-
-                const direction = new THREE.Vector3()
-                    .subVectors(targetPos, tankPos)
-                    .normalize();
-
-                const distance = tankPos.distanceTo(targetPos);
-
-                // Get weapon range for attack distance
-                const attackRange = tank.currentWeapon ? tank.currentWeapon.range : 2.0;
-                const minDistance = attackRange * 0.8;
-
-                if (distance > minDistance) {
-                    // Move towards target
-                    tank.move(direction.x * deltaTime * 2, direction.z * deltaTime * 2);
-
-                    // Clamp to map boundaries
-                    this.clampToMapBoundaries(tank);
-                } else if (distance <= attackRange) {
-                    // Attack if within weapon range
-                    if (Math.random() < 0.03) { // Slightly higher attack chance
-                        tank.attack(this);
-                    }
-                }
-
-                // Face the target
-                tank.group.lookAt(targetPos.x, tankPos.y, targetPos.z);
-            }
-        });
-    }
-
-    chooseAllyTarget(tank) {
-        // Ally tanks only attack enemies
-        const potentialTargets = this.enemies.filter(e => e.health > 0);
-
-        // Find nearest enemy
         let closestTarget = null;
         let closestDistance = Infinity;
 
         potentialTargets.forEach(target => {
-            const dist = tank.group.position.distanceTo(target.group.position);
+            const dist = char.group.position.distanceTo(target.group.position);
             if (dist < closestDistance) {
                 closestDistance = dist;
                 closestTarget = target;
@@ -637,158 +623,160 @@ class Game3D {
         return closestTarget;
     }
 
-    chooseNeutralTarget(tank) {
-        // Neutral tanks attack EVERYONE - player and all enemies
-        const potentialTargets = [
-            this.currentPlayer,
-            ...this.enemies.filter(e => e.health > 0),
-            ...this.neutralTanks.filter(t => t !== tank && t.health > 0)
-        ];
+    // Move an AI character with environment collision (slides along obstacles)
+    tryMoveAI(char, dx, dz) {
+        const adx = dx * char.speedMultiplier;
+        const adz = dz * char.speedMultiplier;
+        const pos = char.group.position;
+        const clear = (x, z) => !this.environment.checkCollision(new THREE.Vector3(pos.x + x, 0, pos.z + z), 0.5);
 
-        // Find nearest target
-        let closestTarget = null;
-        let closestDistance = Infinity;
+        if (clear(adx, adz)) {
+            pos.x += adx;
+            pos.z += adz;
+            char.isWalking = true;
+        } else if (clear(adx, 0)) {
+            pos.x += adx;
+            char.isWalking = true;
+        } else if (clear(0, adz)) {
+            pos.z += adz;
+            char.isWalking = true;
+        }
 
-        potentialTargets.forEach(target => {
-            const dist = tank.group.position.distanceTo(target.group.position);
-            if (dist < closestDistance) {
-                closestDistance = dist;
-                closestTarget = target;
+        this.clampToMapBoundaries(char);
+    }
+
+    updateAICharacter(char, deltaTime) {
+        if (char.health <= 0) return;
+
+        char.aiUpdateTimer -= deltaTime;
+        if (char.aiUpdateTimer <= 0) {
+            char.aiUpdateTimer = 1.5 + Math.random();
+            char.aiTarget = this.chooseTarget(char);
+        }
+
+        const target = char.aiTarget;
+        if (!target || target.health <= 0) return;
+
+        const charPos = char.group.position;
+        const targetPos = target.group.position;
+        const distance = charPos.distanceTo(targetPos);
+
+        const direction = new THREE.Vector3().subVectors(targetPos, charPos);
+        direction.y = 0;
+        direction.normalize();
+
+        const attackRange = char.currentWeapon ? char.currentWeapon.range : 2.0;
+        const step = 2 * deltaTime;
+
+        if (char.prefersRanged) {
+            // Ranged enemies keep their distance and kite
+            if (distance < 5) {
+                this.tryMoveAI(char, -direction.x * step, -direction.z * step);
+            } else if (distance > attackRange * 0.9) {
+                this.tryMoveAI(char, direction.x * step, direction.z * step);
             }
-        });
+            if (distance <= attackRange && char.attackCooldown <= 0 && Math.random() < deltaTime * 1.2) {
+                char.attack(this);
+            }
+        } else {
+            // Melee characters charge in
+            if (distance > attackRange * 0.7) {
+                this.tryMoveAI(char, direction.x * step, direction.z * step);
+            } else if (char.attackCooldown <= 0 && Math.random() < deltaTime * 1.5) {
+                char.attack(this);
+            }
+        }
 
-        return closestTarget;
+        char.group.lookAt(targetPos.x, charPos.y, targetPos.z);
     }
 
     updateEnemies(deltaTime) {
-        this.enemies.forEach(enemy => {
-            if (enemy.health <= 0) return;
-
-            // Update AI target timer
-            enemy.aiUpdateTimer -= deltaTime;
-            if (enemy.aiUpdateTimer <= 0) {
-                // Re-evaluate target every 2-3 seconds
-                enemy.aiUpdateTimer = 2 + Math.random();
-                enemy.aiTarget = this.chooseEnemyTarget(enemy);
-            }
-
-            if (enemy.aiTarget && enemy.aiTarget.health > 0) {
-                const targetPos = enemy.aiTarget.group.position;
-                const enemyPos = enemy.group.position;
-
-                const direction = new THREE.Vector3()
-                    .subVectors(targetPos, enemyPos)
-                    .normalize();
-
-                const distance = enemyPos.distanceTo(targetPos);
-
-                // Smart weapon switching based on distance
-                if (distance > 6 && enemy.currentWeaponIndex !== 4) {
-                    // Far away - switch to pistol
-                    enemy.switchWeapon(4);
-                } else if (distance <= 4 && enemy.currentWeaponIndex === 4) {
-                    // Close range - switch to sword for melee
-                    enemy.switchWeapon(0);
-                }
-
-                // Get weapon range for attack distance
-                const attackRange = enemy.currentWeapon ? enemy.currentWeapon.range : 2.0;
-                const minDistance = attackRange * 0.8; // Stay at 80% of weapon range
-
-                if (distance > minDistance) {
-                    // Move towards target
-                    enemy.move(direction.x * deltaTime * 2, direction.z * deltaTime * 2);
-
-                    // Clamp to map boundaries
-                    this.clampToMapBoundaries(enemy);
-                } else if (distance <= attackRange) {
-                    // Attack if within weapon range
-                    if (Math.random() < 0.02) { // Random attack chance
-                        enemy.attack(this);
-                    }
-                }
-
-                // Face the target
-                enemy.group.lookAt(targetPos.x, enemyPos.y, targetPos.z);
-            }
-        });
+        this.enemies.forEach(enemy => this.updateAICharacter(enemy, deltaTime));
     }
 
-    chooseEnemyTarget(enemy) {
-        // All enemies work together - they only attack player, neutral tanks, and ally tanks
-        const potentialTargets = [
-            this.currentPlayer,
-            ...this.neutralTanks.filter(t => t.health > 0),
-            ...this.allyTanks.filter(t => t.health > 0)
-        ];
+    updateNeutralTanks(deltaTime) {
+        this.neutralTanks.forEach(tank => this.updateAICharacter(tank, deltaTime));
+    }
 
-        // Find nearest target
-        let closestTarget = null;
-        let closestDistance = Infinity;
+    updateAllyTanks(deltaTime) {
+        this.allyTanks.forEach(tank => this.updateAICharacter(tank, deltaTime));
+    }
 
-        potentialTargets.forEach(target => {
-            const dist = enemy.group.position.distanceTo(target.group.position);
-            if (dist < closestDistance) {
-                closestDistance = dist;
-                closestTarget = target;
+    // Keep enemies from stacking on the same spot
+    applySeparation(characters) {
+        const minDist = 1.0;
+        for (let i = 0; i < characters.length; i++) {
+            const a = characters[i];
+            if (a.health <= 0) continue;
+            for (let j = i + 1; j < characters.length; j++) {
+                const b = characters[j];
+                if (b.health <= 0) continue;
+
+                const dx = b.group.position.x - a.group.position.x;
+                const dz = b.group.position.z - a.group.position.z;
+                const distSq = dx * dx + dz * dz;
+                if (distSq > 0.0001 && distSq < minDist * minDist) {
+                    const dist = Math.sqrt(distSq);
+                    const push = (minDist - dist) * 0.5;
+                    const nx = dx / dist;
+                    const nz = dz / dist;
+                    a.group.position.x -= nx * push;
+                    a.group.position.z -= nz * push;
+                    b.group.position.x += nx * push;
+                    b.group.position.z += nz * push;
+                }
             }
-        });
-
-        // Default to player if no other targets
-        return closestTarget || this.currentPlayer;
+        }
     }
 
     checkCollisions() {
-        // Check weapon hits (melee only, crossbows/pistols use arrows)
-        const allCombatants = this.players.concat(this.enemies).concat(this.neutralTanks).concat(this.allyTanks);
+        // Resolve melee strikes. Each swing lands at most once, at the moment
+        // the strike animation connects (meleeHitPending is set by StickFigure).
+        const allCombatants = [...this.players, ...this.enemies, ...this.neutralTanks, ...this.allyTanks];
 
         allCombatants.forEach(attacker => {
-            if (attacker.isAttacking && attacker.currentWeapon) {
-                // Skip ranged weapon attacks - they use arrow projectiles
-                if (attacker.currentWeapon.name === 'Crossbow' || attacker.currentWeapon.name === 'Pistol' || attacker.currentWeapon.name === 'Rifle') {
-                    return;
-                }
+            if (!attacker.meleeHitPending) return;
+            attacker.meleeHitPending = false;
 
-                // Get all potential targets
-                let targets = [];
+            if (!attacker.currentWeapon || attacker.health <= 0) return;
+
+            const weapon = attacker.currentWeapon;
+            const targets = this.getTargetsFor(attacker);
+            let hitSomething = false;
+
+            targets.forEach(target => {
+                if (target.health <= 0) return;
+
+                const distance = attacker.group.position.distanceTo(target.group.position);
+                if (distance >= weapon.range) return;
+
+                // The controlled player only hits what they're facing
                 if (attacker === this.currentPlayer) {
-                    // Player can hit enemies and neutral tanks (NOT ally tanks)
-                    targets = [...this.enemies, ...this.neutralTanks];
-                } else if (attacker.isNeutral) {
-                    // Neutral tanks hit EVERYONE except themselves
-                    targets = [this.currentPlayer, ...this.enemies, ...this.neutralTanks.filter(t => t !== attacker), ...this.allyTanks];
-                } else if (attacker.isAlly) {
-                    // Ally tanks only hit enemies
-                    targets = [...this.enemies];
-                } else {
-                    // Regular enemies work together - only hit player, neutral tanks, and ally tanks (NOT other enemies)
-                    targets = [this.currentPlayer, ...this.neutralTanks, ...this.allyTanks];
+                    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(attacker.group.quaternion);
+                    const toTarget = new THREE.Vector3().subVectors(target.group.position, attacker.group.position).normalize();
+                    if (forward.dot(toTarget) < 0.25) return;
                 }
 
-                targets.forEach(target => {
-                    if (target.health > 0) {
-                        const distance = attacker.group.position.distanceTo(target.group.position);
-                        if (distance < attacker.currentWeapon.range) {
-                            // Apply damage multiplier from attacker
-                            const damage = Math.floor(attacker.currentWeapon.damage * attacker.damageMultiplier);
-                            target.takeDamage(damage);
+                const damage = Combat.calculateDamage(attacker, weapon);
+                target.takeDamage(damage);
+                hitSomething = true;
 
-                            // Update UI if player is hit
-                            if (target === this.currentPlayer) {
-                                document.getElementById('healthValue').textContent = target.health;
-                            }
-                        }
-                    }
-                });
+                Combat.createBloodEffect(this.scene, target.group.position.clone());
+                Combat.showDamageNumber(this.scene, target.group.position.clone(), damage);
+            });
+
+            if (hitSomething && window.Sound) {
+                window.Sound.hit();
             }
         });
     }
 
     updateCoins(deltaTime) {
-        // Update coin animations and check for collection
+        if (!this.currentPlayer) return;
+        const playerPos = this.currentPlayer.group.position;
+
         for (let i = this.coins.length - 1; i >= 0; i--) {
             const coinData = this.coins[i];
-
             if (coinData.collected) continue;
 
             // Spin the coin
@@ -799,46 +787,63 @@ class Game3D {
             coinData.bobPhase += deltaTime * 2;
             coinData.group.position.y = 0.5 + Math.sin(coinData.bobPhase) * 0.15;
 
-            // Check if player is close enough to collect
-            if (this.currentPlayer) {
-                const distance = this.currentPlayer.group.position.distanceTo(coinData.group.position);
+            const distance = playerPos.distanceTo(coinData.group.position);
 
-                if (distance < 1.2) {
-                    // Collect the coin!
-                    this.playerCoins += 1;
-                    coinData.collected = true;
+            // Magnet effect - nearby coins drift toward the player
+            if (distance < 3.5 && distance > 1.0) {
+                const dir = new THREE.Vector3().subVectors(playerPos, coinData.group.position);
+                dir.y = 0;
+                dir.normalize();
+                coinData.group.position.x += dir.x * 6 * deltaTime;
+                coinData.group.position.z += dir.z * 6 * deltaTime;
+            }
 
-                    // Update UI
-                    document.getElementById('coinCount').textContent = this.playerCoins;
+            if (distance < 1.2) {
+                // Collect the coin!
+                this.playerCoins += 1;
+                this.totalCoinsEarned += 1;
+                coinData.collected = true;
 
-                    // Check if player reached 100 coins and hasn't unlocked rifle yet
-                    if (this.playerCoins >= 100 && !this.currentPlayer.hasRifle) {
-                        this.currentPlayer.unlockRifle();
-                        this.playerCoins -= 100; // Deduct the cost
-                        document.getElementById('coinCount').textContent = this.playerCoins;
-                        this.showRifleUnlockedMessage();
-                    }
+                if (window.Sound) window.Sound.coin();
 
-                    // Check if player reached 20 coins and hasn't unlocked bomb yet
-                    if (this.playerCoins >= 20 && this.currentPlayer.hasRifle && !this.currentPlayer.hasBomb) {
-                        this.currentPlayer.unlockBomb();
-                        this.playerCoins -= 20; // Deduct the cost
-                        document.getElementById('coinCount').textContent = this.playerCoins;
-                        this.showBombUnlockedMessage();
-                    }
-
-                    // Remove coin from scene
-                    this.scene.remove(coinData.group);
-                    this.coins.splice(i, 1);
-
-                    console.log('Coin collected! Total coins:', this.playerCoins);
+                // Auto-unlock weapons when affordable
+                if (!this.currentPlayer.hasRifle && this.playerCoins >= this.rifleCost) {
+                    this.playerCoins -= this.rifleCost;
+                    this.currentPlayer.unlockRifle();
+                    this.showRifleUnlockedMessage();
+                    if (window.Sound) window.Sound.unlock();
+                } else if (this.currentPlayer.hasRifle && !this.currentPlayer.hasBomb && this.playerCoins >= this.bombCost) {
+                    this.playerCoins -= this.bombCost;
+                    this.currentPlayer.unlockBomb();
+                    this.showBombUnlockedMessage();
+                    if (window.Sound) window.Sound.unlock();
                 }
+
+                this.updateCoinUI();
+
+                this.scene.remove(coinData.group);
+                this.coins.splice(i, 1);
+            }
+        }
+    }
+
+    updateCoinUI() {
+        const coinCount = document.getElementById('coinCount');
+        if (coinCount) coinCount.textContent = this.playerCoins;
+
+        const goal = document.getElementById('coinGoal');
+        if (goal && this.currentPlayer) {
+            if (!this.currentPlayer.hasRifle) {
+                goal.textContent = ` / ${this.rifleCost} unlocks Rifle`;
+            } else if (!this.currentPlayer.hasBomb) {
+                goal.textContent = ` / ${this.bombCost} unlocks Bomb`;
+            } else {
+                goal.textContent = '';
             }
         }
     }
 
     showRifleUnlockedMessage() {
-        // Remove old message if exists
         const oldMessage = document.getElementById('rifleMessage');
         if (oldMessage) oldMessage.remove();
 
@@ -847,6 +852,8 @@ class Game3D {
         if (weaponSlot6) {
             weaponSlot6.style.opacity = '1';
             weaponSlot6.style.border = '2px solid #FFD700';
+            const label = weaponSlot6.querySelector('small');
+            if (label) label.textContent = 'Rifle';
         }
 
         const messageDiv = document.createElement('div');
@@ -868,7 +875,6 @@ class Game3D {
 
         document.body.appendChild(messageDiv);
 
-        // Remove after 5 seconds
         setTimeout(() => {
             if (messageDiv.parentNode) {
                 messageDiv.parentNode.removeChild(messageDiv);
@@ -877,7 +883,6 @@ class Game3D {
     }
 
     showBombUnlockedMessage() {
-        // Remove old message if exists
         const oldMessage = document.getElementById('bombMessage');
         if (oldMessage) oldMessage.remove();
 
@@ -886,6 +891,8 @@ class Game3D {
         if (weaponSlot7) {
             weaponSlot7.style.opacity = '1';
             weaponSlot7.style.border = '2px solid #FF4500';
+            const label = weaponSlot7.querySelector('small');
+            if (label) label.textContent = 'Bomb';
         }
 
         const messageDiv = document.createElement('div');
@@ -907,7 +914,6 @@ class Game3D {
 
         document.body.appendChild(messageDiv);
 
-        // Remove after 5 seconds
         setTimeout(() => {
             if (messageDiv.parentNode) {
                 messageDiv.parentNode.removeChild(messageDiv);
@@ -918,83 +924,73 @@ class Game3D {
     animate() {
         requestAnimationFrame(this.animate);
 
-        const deltaTime = this.clock.getDelta();
+        // Clamp delta so a backgrounded tab doesn't cause huge jumps
+        const deltaTime = Math.min(this.clock.getDelta(), 0.1);
 
-        this.updatePlayer(deltaTime);
-        this.updateEnemies(deltaTime);
-        this.updateNeutralTanks(deltaTime);
-        this.updateAllyTanks(deltaTime);
-        this.updateArrows(deltaTime);
-        this.updateBombs(deltaTime);
-        this.updateCoins(deltaTime);
-        this.checkCollisions();
-        this.checkDeadEnemies();
-        this.checkTankConversions();
-        this.checkWaveComplete();
+        if (!this.paused && !this.gameOver && !this.gameWon) {
+            this.updatePlayer(deltaTime);
 
-        // Update wave timer
-        if (!this.waveInProgress && this.waveCompleteTimer > 0 && !this.gameWon) {
-            this.waveCompleteTimer -= deltaTime;
-            if (this.waveCompleteTimer <= 0) {
-                console.log(`Wave timer expired, starting next wave`);
-                this.startWave(this.currentWave + 1);
+            // Hold to attack (auto-fire; weapon cooldowns limit the rate)
+            if (this.isMouseDown && this.isPointerLocked && this.currentPlayer && this.currentPlayer.health > 0) {
+                this.currentPlayer.attack(this);
             }
-        }
 
-        // Update all characters including neutral and ally tanks
-        this.players.concat(this.enemies).concat(this.neutralTanks).concat(this.allyTanks).forEach(character => {
-            character.update(deltaTime);
-        });
+            this.updateEnemies(deltaTime);
+            this.updateNeutralTanks(deltaTime);
+            this.updateAllyTanks(deltaTime);
+            this.applySeparation(this.enemies);
+            this.updateArrows(deltaTime);
+            this.updateBombs(deltaTime);
+            this.updateCoins(deltaTime);
+            this.checkCollisions();
+            this.checkDeadEnemies();
+            this.checkTankConversions();
+            this.checkWaveComplete();
+            this.checkPlayerDefeat();
 
-        // Update environment effects (wind)
-        if (this.environment) {
-            this.environment.addWindEffect();
+            // Update wave timer
+            if (!this.waveInProgress && this.waveCompleteTimer > 0 && !this.gameWon) {
+                this.waveCompleteTimer -= deltaTime;
+                if (this.waveCompleteTimer <= 0) {
+                    this.startWave(this.currentWave + 1);
+                }
+            }
+
+            // Update all characters; pass the camera position so health bars can face it
+            const cameraWorldPos = new THREE.Vector3();
+            this.camera.getWorldPosition(cameraWorldPos);
+            [...this.players, ...this.enemies, ...this.neutralTanks, ...this.allyTanks].forEach(character => {
+                character.update(deltaTime, cameraWorldPos);
+            });
+
+            // Update environment effects (wind)
+            if (this.environment) {
+                this.environment.addWindEffect();
+            }
         }
 
         this.renderer.render(this.scene, this.camera);
     }
 
     updateArrows(deltaTime) {
-        // Update all arrows
         for (let i = this.arrows.length - 1; i >= 0; i--) {
             const arrow = this.arrows[i];
             arrow.update(deltaTime);
 
-            // Check collisions with all characters (excluding the shooter)
-            let allTargets = [];
-            if (arrow.owner.isNeutral) {
-                // Neutral tank arrows hit everyone except other neutral tanks
-                allTargets = [this.currentPlayer, ...this.enemies, ...this.allyTanks];
-            } else if (arrow.owner.isAlly) {
-                // Ally tank arrows only hit enemies
-                allTargets = [...this.enemies];
-            } else if (arrow.owner === this.currentPlayer) {
-                // Player arrows hit enemies and neutral tanks (NOT ally tanks)
-                allTargets = [...this.enemies, ...this.neutralTanks];
-            } else {
-                // Enemy arrows work together - only hit player, neutral tanks, and ally tanks (NOT other enemies)
-                allTargets = [this.currentPlayer, ...this.neutralTanks, ...this.allyTanks];
-            }
-
-            const hit = arrow.checkCollision(allTargets);
+            const hit = arrow.checkCollision(this.getTargetsFor(arrow.owner));
 
             if (hit) {
-                // Apply damage multiplier from shooter
-                const damage = Math.floor(hit.damage * arrow.owner.damageMultiplier);
+                // Apply the shooter's damage multiplier with a little variance
+                const damage = Math.max(1, Math.floor(
+                    hit.damage * (arrow.owner.damageMultiplier || 1) * (0.85 + Math.random() * 0.3)
+                ));
                 hit.target.takeDamage(damage);
 
-                console.log('Arrow dealt damage:', damage, 'to target. New health:', hit.target.health);
+                Combat.createBloodEffect(this.scene, hit.target.group.position.clone());
+                Combat.showDamageNumber(this.scene, hit.target.group.position.clone(), damage);
 
-                // Update UI if player is hit
-                if (hit.target === this.currentPlayer) {
-                    document.getElementById('healthValue').textContent = hit.target.health;
-                }
-
-                // Visual effects
-                const Combat = window.Combat || (typeof Combat !== 'undefined' ? Combat : null);
-                if (Combat) {
-                    Combat.createBloodEffect(this.scene, hit.target.group.position.clone());
-                    Combat.showDamageNumber(this.scene, hit.target.group.position.clone(), hit.damage);
+                if (this.players.includes(arrow.owner) && window.Sound) {
+                    window.Sound.hit();
                 }
             }
 
@@ -1006,83 +1002,35 @@ class Game3D {
     }
 
     updateBombs(deltaTime) {
-        // Update all bombs
         for (let i = this.bombs.length - 1; i >= 0; i--) {
             const bomb = this.bombs[i];
             bomb.update(deltaTime);
 
-            // If bomb has exploded, check explosion damage
             if (bomb.hasExploded) {
-                // Check collisions with all characters (excluding the thrower)
-                let allTargets = [];
-                if (bomb.owner.isNeutral) {
-                    // Neutral tank bombs hit everyone except other neutral tanks
-                    allTargets = [this.currentPlayer, ...this.enemies, ...this.allyTanks];
-                } else if (bomb.owner.isAlly) {
-                    // Ally tank bombs only hit enemies
-                    allTargets = [...this.enemies];
-                } else if (bomb.owner === this.currentPlayer) {
-                    // Player bombs hit enemies and neutral tanks (NOT ally tanks)
-                    allTargets = [...this.enemies, ...this.neutralTanks];
-                } else {
-                    // Enemy bombs work together - only hit player, neutral tanks, and ally tanks (NOT other enemies)
-                    allTargets = [this.currentPlayer, ...this.neutralTanks, ...this.allyTanks];
-                }
-
-                const explosionHits = bomb.checkExplosionDamage(allTargets);
+                const explosionHits = bomb.checkExplosionDamage(this.getTargetsFor(bomb.owner));
 
                 explosionHits.forEach(hit => {
-                    // Apply damage multiplier from thrower
-                    const damage = Math.floor(hit.damage * bomb.owner.damageMultiplier);
+                    const damage = Math.max(1, Math.floor(hit.damage * (bomb.owner.damageMultiplier || 1)));
                     hit.target.takeDamage(damage);
 
-                    console.log('💥 Explosion dealt damage:', damage, 'to target. New health:', hit.target.health);
-
-                    // Update UI if player is hit
-                    if (hit.target === this.currentPlayer) {
-                        document.getElementById('healthValue').textContent = hit.target.health;
-                    }
-
-                    // Visual effects
-                    const Combat = window.Combat || (typeof Combat !== 'undefined' ? Combat : null);
-                    if (Combat) {
-                        Combat.createBloodEffect(this.scene, hit.target.group.position.clone());
-                        Combat.showDamageNumber(this.scene, hit.target.group.position.clone(), damage);
-                    }
+                    Combat.createBloodEffect(this.scene, hit.target.group.position.clone());
+                    Combat.showDamageNumber(this.scene, hit.target.group.position.clone(), damage);
                 });
 
                 // Remove bomb after explosion is processed
                 this.bombs.splice(i, 1);
             } else {
-                // Check direct hit (before explosion)
-                let allTargets = [];
-                if (bomb.owner.isNeutral) {
-                    allTargets = [this.currentPlayer, ...this.enemies, ...this.allyTanks];
-                } else if (bomb.owner.isAlly) {
-                    allTargets = [...this.enemies];
-                } else if (bomb.owner === this.currentPlayer) {
-                    allTargets = [...this.enemies, ...this.neutralTanks];
-                } else {
-                    allTargets = [this.currentPlayer, ...this.neutralTanks, ...this.allyTanks];
+                // Direct hit triggers the explosion; damage is applied next frame
+                bomb.checkCollision(this.getTargetsFor(bomb.owner));
+
+                if (!bomb.alive && !bomb.hasExploded) {
+                    this.bombs.splice(i, 1);
                 }
-
-                const hit = bomb.checkCollision(allTargets);
-
-                if (hit) {
-                    // Direct hit triggers explosion, damage will be handled in next update
-                    console.log('💥 Bomb hit target directly!');
-                }
-            }
-
-            // Remove dead bombs
-            if (!bomb.alive && !bomb.hasExploded) {
-                this.bombs.splice(i, 1);
             }
         }
     }
 
     clampToMapBoundaries(character) {
-        // Clamp character position to stay within map boundaries
         character.group.position.x = Math.max(
             this.mapBoundary.minX,
             Math.min(this.mapBoundary.maxX, character.group.position.x)
@@ -1095,14 +1043,11 @@ class Game3D {
 
     toggleCameraMode() {
         if (this.cameraMode === 'first') {
-            // Switch to third person
             this.cameraMode = 'third';
             this.camera.position.set(0, 4, 8);
         } else {
-            // Switch to first person
             this.cameraMode = 'first';
             this.camera.position.set(0, 1.8, 0.5);
         }
-        console.log('Camera mode:', this.cameraMode);
     }
 }

--- a/stick-wars/js/stickman-wars/Multiplayer.js
+++ b/stick-wars/js/stickman-wars/Multiplayer.js
@@ -14,17 +14,25 @@ class MultiplayerManager {
         this.isConnected = false;
     }
 
-    // Simple local multiplayer (split-screen or turn-based)
+    // Simple local multiplayer (shared screen)
     enableLocalMultiplayer() {
+        if (this.localMultiplayerEnabled) return;
+        this.localMultiplayerEnabled = true;
         this.createSecondPlayer();
         this.setupLocalControls();
     }
 
     createSecondPlayer() {
-        // Create second player with different color and position
-        const player2 = new StickFigure(this.game.scene, 5, 0, 5, 0x00ff00, true);
+        const player2 = new StickFigure(this.game.scene, 5, 0, 5, 'warrior', true);
         player2.playerId = 'player2';
+        player2.isHudOwner = false; // Player 1's HUD stays in charge
         this.game.players.push(player2);
+
+        // Tint player 2 blue so the players can tell each other apart
+        const blueMaterial = new THREE.MeshLambertMaterial({ color: 0x0066ff });
+        player2.head.material = blueMaterial;
+        player2.body.material = blueMaterial;
+        player2.baseColor = 0x0066ff;
 
         // Different weapon loadout for variety
         player2.switchWeapon(1); // Start with axe
@@ -56,7 +64,7 @@ class MultiplayerManager {
                         this.game.keys['Player2Right'] = true;
                         break;
                     case 'Numpad0':
-                        player2.attack();
+                        player2.attack(this.game);
                         break;
                     case 'Numpad1':
                         player2.switchWeapon(0);
@@ -112,9 +120,10 @@ class MultiplayerManager {
                 if (this.game.keys['Player2Left']) direction.x -= 1;
                 if (this.game.keys['Player2Right']) direction.x += 1;
 
-                if (direction.length() > 0) {
+                if (direction.length() > 0 && player2.health > 0) {
                     direction.normalize();
                     player2.move(direction.x * moveSpeed, direction.z * moveSpeed);
+                    this.game.clampToMapBoundaries(player2);
                 }
             }
         };
@@ -207,7 +216,7 @@ class MultiplayerManager {
             this.isHost ? 5 : -5,
             0,
             this.isHost ? 5 : -5,
-            this.isHost ? 0x00ff00 : 0x0066ff,
+            'warrior',
             false
         );
         remotePlayer.playerId = this.isHost ? 'guest' : 'host';

--- a/stick-wars/js/stickman-wars/Sound.js
+++ b/stick-wars/js/stickman-wars/Sound.js
@@ -1,0 +1,105 @@
+// Procedural sound effects using the Web Audio API - no audio assets required
+class SoundManager {
+    constructor() {
+        this.ctx = null;
+        this.enabled = true;
+        this.masterVolume = 0.5;
+    }
+
+    ensureContext() {
+        if (!this.enabled) return false;
+        if (!this.ctx) {
+            try {
+                const AudioCtx = window.AudioContext || window.webkitAudioContext;
+                this.ctx = new AudioCtx();
+            } catch (e) {
+                this.enabled = false;
+                return false;
+            }
+        }
+        if (this.ctx.state === 'suspended') {
+            this.ctx.resume();
+        }
+        return true;
+    }
+
+    tone(freq, duration, type = 'square', volume = 0.15, freqEnd = null, delay = 0) {
+        if (!this.ensureContext()) return;
+        const t0 = this.ctx.currentTime + delay;
+        const osc = this.ctx.createOscillator();
+        const gain = this.ctx.createGain();
+        osc.type = type;
+        osc.frequency.setValueAtTime(freq, t0);
+        if (freqEnd !== null) {
+            osc.frequency.exponentialRampToValueAtTime(Math.max(1, freqEnd), t0 + duration);
+        }
+        gain.gain.setValueAtTime(Math.max(0.001, volume * this.masterVolume), t0);
+        gain.gain.exponentialRampToValueAtTime(0.001, t0 + duration);
+        osc.connect(gain);
+        gain.connect(this.ctx.destination);
+        osc.start(t0);
+        osc.stop(t0 + duration + 0.05);
+    }
+
+    noise(duration, volume = 0.2, delay = 0) {
+        if (!this.ensureContext()) return;
+        const t0 = this.ctx.currentTime + delay;
+        const bufferSize = Math.floor(this.ctx.sampleRate * duration);
+        const buffer = this.ctx.createBuffer(1, bufferSize, this.ctx.sampleRate);
+        const data = buffer.getChannelData(0);
+        for (let i = 0; i < bufferSize; i++) {
+            data[i] = (Math.random() * 2 - 1) * (1 - i / bufferSize);
+        }
+        const source = this.ctx.createBufferSource();
+        source.buffer = buffer;
+        const filter = this.ctx.createBiquadFilter();
+        filter.type = 'lowpass';
+        filter.frequency.value = 900;
+        const gain = this.ctx.createGain();
+        gain.gain.setValueAtTime(Math.max(0.001, volume * this.masterVolume), t0);
+        gain.gain.exponentialRampToValueAtTime(0.001, t0 + duration);
+        source.connect(filter);
+        filter.connect(gain);
+        gain.connect(this.ctx.destination);
+        source.start(t0);
+    }
+
+    swing() { this.tone(320, 0.12, 'triangle', 0.08, 90); }
+    shoot() { this.tone(900, 0.08, 'square', 0.06, 220); }
+    hit() { this.tone(160, 0.1, 'sawtooth', 0.1, 70); }
+    playerHurt() { this.tone(110, 0.22, 'sawtooth', 0.16, 50); }
+    coin() {
+        this.tone(950, 0.07, 'sine', 0.08);
+        this.tone(1400, 0.14, 'sine', 0.08, null, 0.07);
+    }
+    explosion() {
+        this.noise(0.6, 0.5);
+        this.tone(85, 0.5, 'sine', 0.3, 28);
+    }
+    reload() {
+        this.tone(500, 0.05, 'square', 0.06);
+        this.tone(700, 0.05, 'square', 0.06, null, 0.12);
+    }
+    waveStart() {
+        this.tone(440, 0.14, 'square', 0.09);
+        this.tone(554, 0.14, 'square', 0.09, null, 0.14);
+        this.tone(659, 0.28, 'square', 0.09, null, 0.28);
+    }
+    unlock() {
+        [523, 659, 784, 1047].forEach((f, i) => this.tone(f, 0.12, 'square', 0.09, null, i * 0.09));
+    }
+    enemyDie() { this.tone(420, 0.28, 'sawtooth', 0.09, 60); }
+    victory() {
+        [523, 659, 784, 1047, 1319].forEach((f, i) => this.tone(f, 0.25, 'triangle', 0.11, null, i * 0.13));
+    }
+    defeat() {
+        [400, 350, 300, 200].forEach((f, i) => this.tone(f, 0.3, 'sawtooth', 0.1, null, i * 0.25));
+    }
+}
+
+window.Sound = new SoundManager();
+
+// Browsers require a user gesture before audio can start
+['click', 'keydown', 'touchstart'].forEach(evt => {
+    document.addEventListener(evt, () => window.Sound.ensureContext(), { passive: true });
+});

--- a/stick-wars/js/stickman-wars/StickFigure.js
+++ b/stick-wars/js/stickman-wars/StickFigure.js
@@ -2,6 +2,7 @@ class StickFigure {
     constructor(scene, x, y, z, characterType = 'warrior', isPlayer = false, isNeutral = false) {
         this.scene = scene;
         this.isPlayer = isPlayer;
+        this.isHudOwner = isPlayer; // Only the main player drives the HUD (player 2 sets this false)
         this.isNeutral = isNeutral; // Neutral units attack everyone
         this.characterType = characterType;
 
@@ -10,6 +11,10 @@ class StickFigure {
 
         this.isAttacking = false;
         this.attackCooldown = 0;
+        this.meleeHitPending = false; // Set when a melee swing should land (consumed by Game3D)
+        this.isFlashing = false;
+        this.aiTarget = null;
+        this.prefersRanged = false;
         this.weapons = [];
         this.currentWeaponIndex = 0;
         this.currentWeapon = null;
@@ -30,32 +35,29 @@ class StickFigure {
 
     setCharacterStats(type) {
         const stats = {
-            warrior: { health: 3000, speed: 1.0, damage: 1.2 }, // Player health
-            rogue: { health: 4000, speed: 1.4, damage: 1.0 }, // Enemy health
-            mage: { health: 4000, speed: 0.8, damage: 1.5 }, // Enemy health
-            tank: { health: 4000, speed: 0.7, damage: 0.9 }, // Enemy health
-            archer: { health: 4000, speed: 1.2, damage: 1.1 }, // Enemy health
-            skateboarder: { health: 3500, speed: 4.0, damage: 1.0 }, // Super fast skateboard enemy!
-            neutralTank: { health: 10000, speed: 0.5, damage: 3.0 } // Neutral super tank
+            warrior: { health: 90, speed: 1.0, damage: 1.0 },
+            rogue: { health: 70, speed: 1.3, damage: 0.9 },
+            mage: { health: 55, speed: 0.8, damage: 1.3 },
+            tank: { health: 140, speed: 0.6, damage: 1.1 },
+            archer: { health: 60, speed: 1.1, damage: 1.0 },
+            skateboarder: { health: 50, speed: 2.2, damage: 0.8 }, // Fast hit-and-run attacker
+            neutralTank: { health: 500, speed: 0.5, damage: 2.5 } // Neutral super tank
         };
 
         const charStats = stats[type] || stats.warrior;
 
-        // Special case: if this is a player character, use player stats
-        if (this.isPlayer && type === 'warrior') {
-            this.health = 3000;
-            this.maxHealth = 3000;
-        } else if (this.isNeutral && type === 'neutralTank') {
-            // Neutral tank gets massive health
-            this.health = charStats.health;
-            this.maxHealth = charStats.health;
+        if (this.isPlayer) {
+            // Player is tougher and hits harder than a regular warrior
+            this.health = 200;
+            this.maxHealth = 200;
+            this.speedMultiplier = 1.0;
+            this.damageMultiplier = 1.2;
         } else {
             this.health = charStats.health;
             this.maxHealth = charStats.health;
+            this.speedMultiplier = charStats.speed;
+            this.damageMultiplier = charStats.damage;
         }
-
-        this.speedMultiplier = charStats.speed;
-        this.damageMultiplier = charStats.damage;
 
         // Set color based on player/enemy/neutral
         if (this.isPlayer) {
@@ -392,21 +394,27 @@ class StickFigure {
     }
 
     initializeWeapons() {
+        // damage / range / color; cooldowns set below
         this.weapons = [
-            new Weapon('Sword', 30, 2.0, 0x888888),
-            new Weapon('Axe', 35, 1.8, 0x8B4513),
-            new Weapon('Spear', 20, 3.0, 0x654321),
-            new Weapon('Hammer', 40, 1.5, 0x696969),
-            new Weapon('Crossbow', 100, 7.0, 0x4A4A4A),
-            null, // Rifle slot - unlocked with 100 coins
-            null  // Bomb slot - unlocked with 200 coins
+            new Weapon('Sword', 25, 2.2, 0x888888),   // Fast all-rounder
+            new Weapon('Axe', 40, 2.0, 0x8B4513),     // Slower, heavier hits
+            new Weapon('Spear', 30, 3.2, 0x654321),   // Extra reach
+            new Weapon('Hammer', 60, 1.8, 0x696969),  // Slow but devastating
+            new Weapon('Crossbow', 35, 12.0, 0x4A4A4A), // Ranged
+            null, // Rifle slot - unlocked with coins
+            null  // Bomb slot - unlocked with coins
         ];
 
-        // Set crossbow stats
-        this.weapons[4].cooldown = 0.2; // Very fast fire rate
-        this.weapons[4].maxAmmo = 10; // 10 bolts per reload
+        this.weapons[0].cooldown = 0.5;
+        this.weapons[1].cooldown = 0.8;
+        this.weapons[2].cooldown = 0.7;
+        this.weapons[3].cooldown = 1.2;
+
+        // Crossbow ammo / fire rate
+        this.weapons[4].cooldown = 0.6;
+        this.weapons[4].maxAmmo = 10;
         this.weapons[4].currentAmmo = 10;
-        this.weapons[4].reloadTime = 1.5; // 1.5 seconds to reload
+        this.weapons[4].reloadTime = 1.5;
 
         this.currentWeapon = this.weapons[0];
         this.currentWeapon.attachTo(this.rightArm);
@@ -418,22 +426,15 @@ class StickFigure {
 
     unlockRifle() {
         if (!this.hasRifle) {
-            console.log('Creating rifle weapon...');
-            // Create the rifle weapon
-            const rifle = new Weapon('Rifle', 200, 15.0, 0x2F4F4F);
+            const rifle = new Weapon('Rifle', 22, 15.0, 0x2F4F4F);
 
-            // Set rifle stats
             rifle.cooldown = 0.15; // Fast fire rate
-            rifle.maxAmmo = 30; // 30 bullets per reload
+            rifle.maxAmmo = 30;
             rifle.currentAmmo = 30;
-            rifle.reloadTime = 2.0; // 2 seconds to reload
+            rifle.reloadTime = 2.0;
 
-            // Add to weapons array
             this.weapons[5] = rifle;
             this.hasRifle = true;
-
-            console.log('Rifle unlocked! Weapon:', rifle);
-            console.log('Weapons array:', this.weapons);
 
             // Auto-switch to rifle
             if (this.isPlayer) {
@@ -449,23 +450,16 @@ class StickFigure {
 
     unlockBomb() {
         if (!this.hasBomb) {
-            console.log('Creating bomb weapon...');
-            // Create the bomb weapon
-            const bomb = new Weapon('Bomb', 500, 5.0, 0xFF4500);
+            const bomb = new Weapon('Bomb', 120, 5.0, 0xFF4500);
 
-            // Set bomb stats
-            bomb.cooldown = 1.5; // Slower fire rate (grenades take time)
-            bomb.maxAmmo = 5; // 5 bombs per reload
+            bomb.cooldown = 1.5; // Grenades take time to throw
+            bomb.maxAmmo = 5;
             bomb.currentAmmo = 5;
-            bomb.reloadTime = 3.0; // 3 seconds to reload
+            bomb.reloadTime = 3.0;
             bomb.explosionRadius = 4.0; // Area of effect damage
 
-            // Add to weapons array
             this.weapons[6] = bomb;
             this.hasBomb = true;
-
-            console.log('Bomb unlocked! Weapon:', bomb);
-            console.log('Weapons array:', this.weapons);
 
             // Auto-switch to bomb
             if (this.isPlayer) {
@@ -480,8 +474,6 @@ class StickFigure {
     }
 
     switchWeapon(index) {
-        console.log(`Attempting to switch to weapon ${index}, weapon exists:`, this.weapons[index] !== null);
-
         if (index >= 0 && index < this.weapons.length && this.weapons[index] !== null) {
             // Remove current weapon
             if (this.currentWeapon) {
@@ -493,19 +485,13 @@ class StickFigure {
             this.currentWeapon = this.weapons[index];
             this.currentWeapon.attachTo(this.rightArm);
 
-            console.log(`Switched to weapon: ${this.currentWeapon.name}`);
-
-            // Update UI
-            if (this.isPlayer) {
-                if (this.currentWeapon.maxAmmo !== null) {
-                    document.getElementById('currentWeapon').textContent =
-                        `${this.currentWeapon.name} (${this.currentWeapon.currentAmmo}/${this.currentWeapon.maxAmmo})`;
-                } else {
-                    document.getElementById('currentWeapon').textContent = this.currentWeapon.name;
-                }
+            // Update UI (weapon text + slot highlight)
+            if (this.isHudOwner) {
+                this.updateAmmoUI();
+                document.querySelectorAll('.weapon-slot').forEach(slot => slot.classList.remove('active'));
+                const slot = document.querySelector(`[data-weapon="${index}"]`);
+                if (slot) slot.classList.add('active');
             }
-        } else {
-            console.log(`Cannot switch to weapon ${index} - not available`);
         }
     }
 
@@ -532,63 +518,54 @@ class StickFigure {
     }
 
     attack(gameInstance) {
-        if (this.attackCooldown <= 0 && this.currentWeapon && !this.currentWeapon.isReloading) {
-            console.log(`Attacking with weapon: ${this.currentWeapon.name}, ammo: ${this.currentWeapon.currentAmmo}`);
+        if (this.health <= 0) return;
+        if (this.attackCooldown > 0 || !this.currentWeapon || this.currentWeapon.isReloading) return;
 
-            // Check if weapon needs ammo and is out
-            if (this.currentWeapon.maxAmmo !== null && this.currentWeapon.currentAmmo <= 0) {
-                console.log('Out of ammo, reloading...');
-                this.reloadWeapon();
-                return;
+        // Check if weapon needs ammo and is out
+        if (this.currentWeapon.maxAmmo !== null && this.currentWeapon.currentAmmo <= 0) {
+            this.reloadWeapon();
+            return;
+        }
+
+        this.isAttacking = true;
+        this.attackCooldown = this.currentWeapon.cooldown;
+
+        const weaponName = this.currentWeapon.name;
+
+        if (weaponName === 'Bomb' && gameInstance) {
+            if (this.currentWeapon.currentAmmo !== null) {
+                this.currentWeapon.currentAmmo--;
+                this.updateAmmoUI();
             }
 
-            this.isAttacking = true;
-            this.attackCooldown = this.currentWeapon.cooldown;
-
-            // Check if using bomb
-            if (this.currentWeapon.name === 'Bomb' && gameInstance) {
-                console.log('Throwing bomb!');
-
-                // Use ammo
-                if (this.currentWeapon.currentAmmo !== null) {
-                    this.currentWeapon.currentAmmo--;
-                    this.updateAmmoUI();
-                }
-
-                // Throw bomb
-                this.throwBomb(gameInstance);
-
-                // Throwing animation
-                this.performThrowAnimation();
+            this.throwBomb(gameInstance);
+            this.performThrowAnimation();
+            if (this.isPlayer && window.Sound) window.Sound.swing();
+        }
+        // Ranged weapons shoot a projectile instead of melee
+        else if ((weaponName === 'Crossbow' || weaponName === 'Rifle') && gameInstance) {
+            if (this.currentWeapon.currentAmmo !== null) {
+                this.currentWeapon.currentAmmo--;
+                this.updateAmmoUI();
             }
-            // Check if using ranged weapon - shoot projectile instead of melee
-            else if ((this.currentWeapon.name === 'Crossbow' || this.currentWeapon.name === 'Rifle') && gameInstance) {
-                console.log('Firing ranged weapon:', this.currentWeapon.name);
 
-                // Use ammo
-                if (this.currentWeapon.currentAmmo !== null) {
-                    this.currentWeapon.currentAmmo--;
-                    this.updateAmmoUI();
-                }
+            this.shootArrow(gameInstance);
 
-                // Shoot projectile (using arrow system)
-                this.shootArrow(gameInstance);
-
-                // Shooting animation
-                if (this.currentWeapon.name === 'Rifle') {
-                    this.performRifleAnimation();
-                } else {
-                    this.performCrossbowAnimation();
-                }
+            if (weaponName === 'Rifle') {
+                this.performRifleAnimation();
             } else {
-                console.log('Performing melee attack');
-                // Melee attack animation based on weapon
-                this.performMeleeAnimation();
+                this.performCrossbowAnimation();
             }
+            if (this.isPlayer && window.Sound) window.Sound.shoot();
+        } else {
+            // Melee attack animation; the hit lands mid-swing via meleeHitPending
+            this.performMeleeAnimation();
+            if (this.isPlayer && window.Sound) window.Sound.swing();
         }
     }
 
     reloadWeapon() {
+        if (!this.currentWeapon) return;
         if (this.currentWeapon.isReloading || this.currentWeapon.maxAmmo === null) return;
         if (this.currentWeapon.currentAmmo >= this.currentWeapon.maxAmmo) return;
 
@@ -596,14 +573,38 @@ class StickFigure {
         this.currentWeapon.reloadProgress = 0;
 
         if (this.isPlayer) {
-            console.log('Reloading...');
+            this.updateAmmoUI();
+            if (window.Sound) window.Sound.reload();
         }
     }
 
     updateAmmoUI() {
-        if (this.isPlayer && this.currentWeapon.maxAmmo !== null) {
-            const weaponText = document.getElementById('currentWeapon');
-            weaponText.textContent = `${this.currentWeapon.name} (${this.currentWeapon.currentAmmo}/${this.currentWeapon.maxAmmo})`;
+        if (!this.isHudOwner || !this.currentWeapon) return;
+        const weaponText = document.getElementById('currentWeapon');
+        if (!weaponText) return;
+
+        if (this.currentWeapon.maxAmmo !== null) {
+            weaponText.textContent = this.currentWeapon.isReloading
+                ? `${this.currentWeapon.name} (Reloading...)`
+                : `${this.currentWeapon.name} (${this.currentWeapon.currentAmmo}/${this.currentWeapon.maxAmmo})`;
+        } else {
+            weaponText.textContent = this.currentWeapon.name;
+        }
+    }
+
+    updateHealthUI() {
+        if (!this.isHudOwner) return;
+
+        const healthValue = document.getElementById('healthValue');
+        if (healthValue) {
+            healthValue.textContent = `${Math.max(0, Math.ceil(this.health))}/${this.maxHealth}`;
+        }
+
+        const bar = document.getElementById('healthBarInner');
+        if (bar) {
+            const pct = Math.max(0, this.health / this.maxHealth);
+            bar.style.width = (pct * 100) + '%';
+            bar.style.background = pct > 0.6 ? '#4CAF50' : (pct > 0.3 ? '#FFC107' : '#F44336');
         }
     }
 
@@ -739,6 +740,9 @@ class StickFigure {
             this.body.rotation.x = 0.15;
             this.body.rotation.z = 0.1;
 
+            // This is the moment the swing connects - Game3D resolves the hit
+            this.meleeHitPending = true;
+
             // Step forward (only if character has legs)
             if (this.leftLeg && this.rightLeg) {
                 this.leftLeg.rotation.x = 0.3;
@@ -765,56 +769,51 @@ class StickFigure {
         }, 150);
     }
 
-    shootArrow(gameInstance) {
-        // Get shooting direction from where character is facing
+    getShootDirection(gameInstance) {
+        // AI characters aim straight at their target (lookAt points the model's
+        // +Z at the target, so deriving the direction from the facing would
+        // fire backwards). A bit of spread keeps them beatable.
+        if (!this.isPlayer && this.aiTarget && this.aiTarget.health > 0) {
+            const direction = new THREE.Vector3()
+                .subVectors(this.aiTarget.group.position, this.group.position);
+            direction.y = 0;
+            direction.normalize();
+            direction.x += (Math.random() - 0.5) * 0.12;
+            direction.z += (Math.random() - 0.5) * 0.12;
+            direction.y = 0.02 + (Math.random() - 0.5) * 0.04;
+            return direction.normalize();
+        }
+
+        // Players shoot where they're facing
         const direction = new THREE.Vector3(0, 0, -1);
         direction.applyQuaternion(this.group.quaternion);
-
-        // Normalize to ensure consistent speed
         direction.normalize();
 
-        // Rifles shoot straighter, crossbows have slight arc
-        if (this.currentWeapon.name === 'Rifle') {
-            direction.y += 0.02; // Very slight upward angle
-        } else {
-            direction.y += 0.05; // Slight upward angle for realistic arc
+        // Apply the camera pitch so aiming up/down works
+        if (this.isPlayer && gameInstance && gameInstance.camera) {
+            direction.y = Math.tan(gameInstance.camera.rotation.x);
         }
-        direction.normalize();
 
-        // Create and add arrow/bullet
+        // Slight upward arc to compensate for gravity (rifles shoot flatter)
+        direction.y += (this.currentWeapon && this.currentWeapon.name === 'Rifle') ? 0.01 : 0.04;
+        return direction.normalize();
+    }
+
+    shootArrow(gameInstance) {
+        const direction = this.getShootDirection(gameInstance);
         const arrow = new Arrow(this.scene, this.group.position.clone(), direction, this);
         gameInstance.arrows.push(arrow);
-
-        // Debug: log projectile creation
-        console.log('Projectile shot by', this.isPlayer ? 'player' : 'enemy',
-                    'weapon:', this.currentWeapon.name,
-                    'damage:', this.currentWeapon.damage,
-                    'at position', this.group.position,
-                    'direction', direction);
     }
 
     throwBomb(gameInstance) {
-        // Get throwing direction from where character is facing
-        const direction = new THREE.Vector3(0, 0, -1);
-        direction.applyQuaternion(this.group.quaternion);
+        const direction = this.getShootDirection(gameInstance);
 
-        // Normalize to ensure consistent speed
+        // Bombs are lobbed in a high arc
+        direction.y += 0.4;
         direction.normalize();
 
-        // Bombs are thrown in an arc
-        direction.y += 0.4; // High arc for grenade throw
-        direction.normalize();
-
-        // Create and add bomb
         const bomb = new Bomb(this.scene, this.group.position.clone(), direction, this);
         gameInstance.bombs.push(bomb);
-
-        // Debug: log bomb creation
-        console.log('💣 Bomb thrown by', this.isPlayer ? 'player' : 'enemy',
-                    'damage:', this.currentWeapon.damage,
-                    'explosion radius:', this.currentWeapon.explosionRadius,
-                    'at position', this.group.position,
-                    'direction', direction);
     }
 
     performThrowAnimation() {
@@ -868,18 +867,27 @@ class StickFigure {
     }
 
     takeDamage(amount) {
-        const oldHealth = this.health;
+        if (this.health <= 0) return; // Already down
+
         this.health = Math.max(0, this.health - amount);
 
-        console.log('takeDamage called:', 'Amount:', amount, 'Old Health:', oldHealth, 'New Health:', this.health, 'isPlayer:', this.isPlayer, 'hasHealthBar:', !!this.healthBar);
+        if (this.isPlayer) {
+            if (window.Sound) window.Sound.playerHurt();
+            this.updateHealthUI();
 
-        // Update health bar for enemies
-        if (!this.isPlayer && this.healthBar) {
+            // Red vignette flash so getting hit is obvious
+            if (this.isHudOwner) {
+                const overlay = document.getElementById('damageOverlay');
+                if (overlay) {
+                    overlay.style.opacity = '0.55';
+                    clearTimeout(this.vignetteTimer);
+                    this.vignetteTimer = setTimeout(() => { overlay.style.opacity = '0'; }, 150);
+                }
+            }
+        } else if (this.healthBar) {
             const healthPercent = this.health / this.maxHealth;
-            this.healthBar.scale.x = healthPercent;
+            this.healthBar.scale.x = Math.max(0.001, healthPercent);
             this.healthBar.position.x = (healthPercent - 1) * 0.5;
-
-            console.log('Updating health bar:', 'healthPercent:', healthPercent, 'scale.x:', this.healthBar.scale.x);
 
             // Change color based on health
             if (healthPercent > 0.6) {
@@ -889,8 +897,6 @@ class StickFigure {
             } else {
                 this.healthBar.material.color.setHex(0xff0000);
             }
-        } else if (!this.isPlayer && !this.healthBar) {
-            console.warn('Enemy has no health bar!');
         }
 
         // Death or conversion
@@ -901,6 +907,7 @@ class StickFigure {
             } else {
                 this.die();
             }
+            return;
         }
 
         // Damage effect
@@ -979,8 +986,12 @@ class StickFigure {
     }
 
     showDamageEffect() {
+        // Don't stack flashes - overlapping hits would capture red as the
+        // "original" color and leave the figure permanently red
+        if (this.isFlashing) return;
+        this.isFlashing = true;
+
         // Flash red briefly
-        const originalColor = this.head.material.color.clone();
         this.head.material.color.setHex(0xff0000);
         this.body.material.color.setHex(0xff0000);
 
@@ -1003,21 +1014,24 @@ class StickFigure {
         this.head.rotation.x = -0.2;
 
         setTimeout(() => {
-            // Return color and position
-            this.head.material.color.copy(originalColor);
-            this.body.material.color.copy(originalColor);
+            // Restore the faction color and pose
+            this.head.material.color.setHex(this.baseColor);
+            this.body.material.color.setHex(this.baseColor);
 
             this.body.rotation.x = originalBodyRotX;
             this.body.rotation.z = originalBodyRotZ;
             this.leftArm.rotation.x = originalLeftArmRotX;
             this.rightArm.rotation.x = originalRightArmRotX;
             this.head.rotation.x = originalHeadRotX;
+            this.isFlashing = false;
         }, 150);
     }
 
     die() {
         // Store death position for coin drop
         this.deathPosition = this.group.position.clone();
+
+        if (!this.isPlayer && window.Sound) window.Sound.enemyDie();
 
         // Dramatic death animation
         let fallProgress = 0;
@@ -1058,8 +1072,9 @@ class StickFigure {
 
             if (fallProgress < 1) {
                 requestAnimationFrame(deathAnimation);
-            } else {
-                // Final position - fully collapsed
+            } else if (!this.isPlayer) {
+                // Remove the body after a moment. The player group stays -
+                // the camera is parented to it and must remain valid.
                 setTimeout(() => {
                     this.scene.remove(this.group);
                 }, 1000);
@@ -1069,7 +1084,7 @@ class StickFigure {
         deathAnimation();
     }
 
-    update(deltaTime) {
+    update(deltaTime, cameraPosition) {
         // Update attack cooldown
         if (this.attackCooldown > 0) {
             this.attackCooldown -= deltaTime;
@@ -1086,11 +1101,13 @@ class StickFigure {
                 this.currentWeapon.reloadProgress = 0;
 
                 if (this.isPlayer) {
-                    console.log('Reload complete!');
                     this.updateAmmoUI();
                 }
             }
         }
+
+        // Dead characters are owned by the death animation - don't fight it
+        if (this.health <= 0) return;
 
         // Idle animation - breathing
         if (!this.isWalking && !this.isAttacking && this.health > 0) {
@@ -1176,9 +1193,9 @@ class StickFigure {
             }
         }
 
-        // Make health bar face camera (for enemies)
-        if (this.healthBarGroup && this.scene.children[0] && this.scene.children[0].type === 'PerspectiveCamera') {
-            this.healthBarGroup.lookAt(this.scene.children[0].position);
+        // Make health bar face the camera (for enemies)
+        if (this.healthBarGroup && cameraPosition) {
+            this.healthBarGroup.lookAt(cameraPosition);
         }
 
         this.isWalking = false;


### PR DESCRIPTION
Bug fixes:
- Melee damage applied every animation frame (~20x intended); now lands
  once per swing at the moment of impact
- TDZ crash on every projectile/explosion hit suppressed all hit effects
  and skipped the rest of the frame's game logic
- Enemy ranged attacks fired away from their target (lookAt faces +Z but
  projectiles launched along -Z); AI now aims directly at its target
- Player WASD movement used an inverted rotation and drifted off-axis;
  first-person mode ignored facing entirely
- Enemy health bars billboarded toward the ambient light, not the camera
- Weapon key 7 unusable; keyboard switching didn't sync the weapon bar
- Player death detached the camera and the game kept running; added a
  proper frozen game-over state
- Damage flash could stick figures permanently red on overlapping hits
- Inconsistent bomb unlock cost (20 vs 200); now rifle 100 / bomb 150
  with HUD progress
- Enemies spawned on top of the player; now ring-spawn away from them
- Mobile attack button was covered by the look-touch area
- Local 2P: wrong constructor args, controls never registered, and
  player 2's attacks hurt player 1; removed unconnectable online mode

Balance & AI:
- Sane HP/damage numbers (player 200 HP, enemies 50-140 by type),
  weapon speed/damage tradeoffs, gentler wave scaling
- Melee enemies charge with type-specific weapons; archers/mages kite;
  enemies slide around obstacles and separate instead of stacking

Polish:
- Procedural Web Audio sound effects (no assets needed)
- HUD health bar, damage vignette, reload indicator, named weapon slots
- Pause key, hold-to-attack (desktop + mobile), coin magnet,
  wave/victory/defeat screens with run stats

https://claude.ai/code/session_01Wn5pGBTnvicTzb54jXiruo