### PR TITLE
Fix golden scarecrow not working in non-garden biomes

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -1125,6 +1125,8 @@ const ENEMY_TYPES_JUNGLE = [
   { id:'poison_monk',name:'Poison Monkey',       hp:70,  spd:1.6, dmg:10, straw:16,  sz:1,    color:0x4a7c20, ranged:true },
   { id:'troop',      name:'Monkey Troop',         hp:28,  spd:3.5, dmg:4,  straw:6,   sz:0.8,  color:0x9b6a3c },
   { id:'kong',       name:'Mega Kong',             hp:750, spd:0.6, dmg:30, straw:120, sz:2.8,  color:0x0f0a05 },
+  { id:'golden',     name:'Golden Chimp',           hp:260, spd:1.3, dmg:15, straw:200, sz:1.25, color:0xFFD700 },
+  { id:'guard',      name:'Guard Chimp',             hp:40,  spd:2.8, dmg:5,  straw:3,   sz:0.85, color:0x996633 },
 ];
 const WAVES_JUNGLE = [
   [{t:'chimp',n:5}],
@@ -1132,12 +1134,12 @@ const WAVES_JUNGLE = [
   [{t:'chimp',n:3},{t:'howler',n:3}],
   [{t:'thrower',n:4},{t:'poison_monk',n:2}],
   [{t:'howler',n:3},{t:'alpha',n:2},{t:'chimp_boss',n:1}],
-  [{t:'chimp',n:6},{t:'thrower',n:3},{t:'howler',n:2}],
+  [{t:'chimp',n:6},{t:'thrower',n:3},{t:'howler',n:2},{t:'golden',n:1}],
   [{t:'alpha',n:3},{t:'poison_monk',n:3}],
   [{t:'chimp_boss',n:1},{t:'alpha',n:2},{t:'thrower',n:4}],
   [{t:'chimp',n:8},{t:'howler',n:4}],
   [{t:'alpha',n:4},{t:'poison_monk',n:4},{t:'chimp_boss',n:1}],
-  [{t:'thrower',n:6},{t:'howler',n:4},{t:'alpha',n:2}],
+  [{t:'thrower',n:6},{t:'howler',n:4},{t:'alpha',n:2},{t:'golden',n:1}],
   [{t:'chimp_boss',n:2},{t:'alpha',n:3},{t:'poison_monk',n:2}],
   [{t:'chimp',n:10},{t:'poison_monk',n:4},{t:'thrower',n:4}],
   [{t:'howler',n:5},{t:'alpha',n:4},{t:'poison_monk',n:3}],
@@ -1148,7 +1150,7 @@ const WAVES_JUNGLE = [
   [{t:'alpha',n:6},{t:'howler',n:6},{t:'poison_monk',n:5},{t:'chimp_boss',n:2}],
   [{t:'chimp_boss',n:5},{t:'alpha',n:6},{t:'poison_monk',n:6},{t:'howler',n:4}],
   [{t:'spider_monk',n:12},{t:'bomb_monk',n:4},{t:'chimp',n:6}],
-  [{t:'kong',n:1},{t:'stealth_monk',n:5},{t:'alpha',n:4}],
+  [{t:'kong',n:1},{t:'stealth_monk',n:5},{t:'alpha',n:4},{t:'golden',n:1}],
   [{t:'troop',n:15},{t:'spider_monk',n:8},{t:'bomb_monk',n:4},{t:'howler',n:4}],
   [{t:'kong',n:2},{t:'spider_monk',n:10},{t:'stealth_monk',n:8}],
   [{t:'chimp_boss',n:4},{t:'bomb_monk',n:6},{t:'troop',n:10},{t:'alpha',n:5}],
@@ -1211,6 +1213,8 @@ const ENEMY_TYPES_SNOW = [
   { id:'yeti',          name:'Yeti',              hp:320, spd:1.3, dmg:22, straw:85,  sz:1.7,  color:0xeeeedd },
   { id:'snow_troop',    name:'Snow Troop',        hp:30,  spd:3.2, dmg:4,  straw:6,   sz:0.85, color:0xccddee },
   { id:'glacier',       name:'Glacier Giant',     hp:800, spd:0.5, dmg:35, straw:130, sz:2.9,  color:0x6688aa },
+  { id:'golden',        name:'Golden Frosty',      hp:260, spd:1.3, dmg:15, straw:200, sz:1.25, color:0xFFD700 },
+  { id:'guard',         name:'Guard Snowman',       hp:40,  spd:2.8, dmg:5,  straw:3,   sz:0.85, color:0xaabbcc },
 ];
 const WAVES_SNOW = [
   [{t:'snow_basic',n:5}],
@@ -1218,12 +1222,12 @@ const WAVES_SNOW = [
   [{t:'snow_basic',n:3},{t:'snow_thrower',n:3}],
   [{t:'snow_thrower',n:4},{t:'snow_speedy',n:3}],
   [{t:'snow_thrower',n:3},{t:'snow_armor',n:2},{t:'snow_boss',n:1}],
-  [{t:'snow_basic',n:6},{t:'snow_thrower',n:3},{t:'snow_speedy',n:2}],
+  [{t:'snow_basic',n:6},{t:'snow_thrower',n:3},{t:'snow_speedy',n:2},{t:'golden',n:1}],
   [{t:'snow_armor',n:3},{t:'snow_thrower',n:3}],
   [{t:'snow_boss',n:1},{t:'snow_armor',n:2},{t:'snow_thrower',n:4}],
   [{t:'snow_basic',n:8},{t:'snow_thrower',n:4}],
   [{t:'snow_armor',n:4},{t:'snow_speedy',n:6},{t:'snow_boss',n:1}],
-  [{t:'snow_thrower',n:6},{t:'snow_armor',n:4},{t:'yeti',n:1}],
+  [{t:'snow_thrower',n:6},{t:'snow_armor',n:4},{t:'yeti',n:1},{t:'golden',n:1}],
   [{t:'snow_boss',n:2},{t:'snow_armor',n:3},{t:'snow_speedy',n:4}],
   [{t:'snow_basic',n:10},{t:'snow_speedy',n:5},{t:'snow_thrower',n:4}],
   [{t:'snow_thrower',n:5},{t:'snow_armor',n:4},{t:'yeti',n:2}],
@@ -1234,7 +1238,7 @@ const WAVES_SNOW = [
   [{t:'snow_armor',n:6},{t:'snow_thrower',n:6},{t:'snow_speedy',n:5},{t:'snow_boss',n:2}],
   [{t:'snow_boss',n:5},{t:'snow_armor',n:6},{t:'yeti',n:2},{t:'snow_thrower',n:4}],
   [{t:'snow_speedy',n:12},{t:'snow_bomb',n:4},{t:'snow_basic',n:6}],
-  [{t:'snow_giant',n:1},{t:'snow_shadow',n:5},{t:'snow_armor',n:4}],
+  [{t:'snow_giant',n:1},{t:'snow_shadow',n:5},{t:'snow_armor',n:4},{t:'golden',n:1}],
   [{t:'snow_troop',n:14},{t:'snow_bomb',n:4},{t:'snow_thrower',n:5},{t:'yeti',n:1}],
   [{t:'glacier',n:2},{t:'snow_speedy',n:12},{t:'snow_shadow',n:8}],
   [{t:'snow_boss',n:4},{t:'snow_bomb',n:6},{t:'yeti',n:3},{t:'snow_armor',n:5}],
@@ -1290,6 +1294,8 @@ const ENEMY_TYPES_DEEPSEA = [
   { id:'giant_crab', name:'Giant Crab',       hp:320, spd:0.9, dmg:20, straw:60,  sz:1.8,  color:0xaa3300, armor:0.3 },
   { id:'leviathan',  name:'Leviathan',        hp:800, spd:0.6, dmg:30, straw:140, sz:3.0,  color:0x001133 },
   { id:'ghost_fish', name:'Ghost Fish',       hp:40,  spd:5.0, dmg:6,  straw:8,   sz:0.75, color:0x88ccee },
+  { id:'golden',     name:'Golden Fish',      hp:260, spd:1.3, dmg:15, straw:200, sz:1.25, color:0xFFD700 },
+  { id:'guard',      name:'Guard Crab',       hp:40,  spd:2.8, dmg:5,  straw:3,   sz:0.85, color:0xdd6644 },
 ];
 const WAVES_DEEPSEA = [
   [{t:'clownfish',n:5}],
@@ -1297,12 +1303,12 @@ const WAVES_DEEPSEA = [
   [{t:'crab',n:3},{t:'jellyfish',n:3}],
   [{t:'jellyfish',n:4},{t:'clownfish',n:4}],
   [{t:'anglerfish',n:3},{t:'crab',n:3},{t:'deep_boss',n:1}],
-  [{t:'clownfish',n:6},{t:'eel',n:3},{t:'jellyfish',n:3}],
+  [{t:'clownfish',n:6},{t:'eel',n:3},{t:'jellyfish',n:3},{t:'golden',n:1}],
   [{t:'seahorse',n:4},{t:'anglerfish',n:3}],
   [{t:'shark',n:3},{t:'mermaid',n:4}],
   [{t:'crab',n:5},{t:'nautilus',n:2},{t:'eel',n:3}],
   [{t:'deep_boss',n:2},{t:'anglerfish',n:4},{t:'jellyfish',n:5}],
-  [{t:'shark',n:5},{t:'ghost_fish',n:8},{t:'mermaid',n:3}],
+  [{t:'shark',n:5},{t:'ghost_fish',n:8},{t:'mermaid',n:3},{t:'golden',n:1}],
   [{t:'pufferfish',n:5},{t:'giant_crab',n:1},{t:'seahorse',n:4}],
   [{t:'nautilus',n:4},{t:'deep_boss',n:2},{t:'eel',n:5}],
   [{t:'ghost_fish',n:10},{t:'shark',n:4},{t:'mermaid',n:4}],
@@ -2514,6 +2520,19 @@ function spawnSeaCreature(data, pos) {
   _addEnemyToScene(g, pos, data, sz);
 }
 
+function _spawnGoldenGuards(data, pos) {
+  if (data.id !== 'golden') return;
+  const goldenEnemy = gs.enemies[gs.enemies.length - 1];
+  for (let i = 0; i < 2; i++) {
+    const ga = (i / 2) * Math.PI * 2 + Math.PI / 6;
+    const gp = new THREE.Vector3(pos.x + Math.cos(ga) * 3.2, 0, pos.z + Math.sin(ga) * 3.2);
+    const gr = Math.hypot(gp.x, gp.z);
+    if (gr > FARM_R - 2) { gp.x *= (FARM_R - 2) / gr; gp.z *= (FARM_R - 2) / gr; }
+    spawnEnemy('guard', gp);
+    gs.enemies[gs.enemies.length - 1]._guardOf = goldenEnemy;
+  }
+}
+
 function spawnEnemy(typeId, atPos = null) {
   const data = getActiveData().enemies.find(e => e.id === typeId);
   if (!data) return;
@@ -2525,9 +2544,9 @@ function spawnEnemy(typeId, atPos = null) {
     const r = FARM_R + 2 + Math.random() * 3;
     pos = new THREE.Vector3(Math.cos(angle) * r, 0, Math.sin(angle) * r);
   }
-  if (gs.biome === 'jungle')  { spawnMonkey(data, pos); return; }
-  if (gs.biome === 'snow')    { spawnSnowman(data, pos); return; }
-  if (gs.biome === 'deepsea') { spawnSeaCreature(data, pos); return; }
+  if (gs.biome === 'jungle')  { spawnMonkey(data, pos);      _spawnGoldenGuards(data, pos); return; }
+  if (gs.biome === 'snow')    { spawnSnowman(data, pos);     _spawnGoldenGuards(data, pos); return; }
+  if (gs.biome === 'deepsea') { spawnSeaCreature(data, pos); _spawnGoldenGuards(data, pos); return; }
   const sz = data.sz || 1;
   const g = new THREE.Group();
   const smat = (col, rough=0.85, met=0, emCol=0, emInt=0) => {


### PR DESCRIPTION
Root cause: 'golden' and 'guard' IDs were missing from jungle/snow/ deepsea enemy arrays, so spawnEnemy() returned early on !data. Also the guard escort-spawning code only ran in the garden path because biome branches returned immediately.

Fix:
- Add golden + guard enemy entries to ENEMY_TYPES_JUNGLE, _SNOW, _DEEPSEA
- Extract guard-spawning into _spawnGoldenGuards() helper
- Call it from each biome dispatch in spawnEnemy()
- Add golden to waves 6, 11, 22 in WAVES_JUNGLE and WAVES_SNOW
- Add golden to waves 6, 11 in WAVES_DEEPSEA (only 20 waves total)

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE