### PR TITLE
Increase all garden scarecrow speeds by ~40%

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -1016,20 +1016,20 @@ const RANDOM_EVENTS = [
 ];
 
 const ENEMY_TYPES = [
-  { id:'basic',  name:'Basic Scarecrow',        hp:40,  spd:2.9, dmg:5,  straw:5,   sz:1,   color:0xd2b48c },
-  { id:'torch',  name:'Torch Scarecrow',        hp:60,  spd:3.5, dmg:8,  straw:10,  sz:1,   color:0xff8c00 },
-  { id:'sword',  name:'Sword Scarecrow',        hp:100, spd:2.2, dmg:15, straw:15,  sz:1,   color:0x808080 },
-  { id:'flame',  name:'Flamethrower Scarecrow', hp:80,  spd:2.6, dmg:12, straw:20,  sz:1,   color:0xff4500, ranged:true },
-  { id:'armor',  name:'Armored Scarecrow',      hp:120, spd:1.8, dmg:14, straw:30,  sz:1,   color:0x4a4a4a, armor:0.25 },
-  { id:'boss',   name:'BOSS Scarecrow',         hp:350, spd:1.8, dmg:18, straw:100, sz:1.8, color:0x8b0000 },
-  { id:'speedy', name:'Speed Demon',            hp:28,  spd:8.0, dmg:5,  straw:8,   sz:0.85,color:0xffee00 },
-  { id:'bomb',   name:'Bomb Scarecrow',         hp:90,  spd:2.3, dmg:14, straw:22,  sz:1.1, color:0x2a2a2a },
-  { id:'ice',    name:'Ice Scarecrow',          hp:75,  spd:2.2, dmg:9,  straw:18,  sz:1,   color:0x88ccff, ranged:true },
-  { id:'shadow', name:'Shadow Scarecrow',       hp:65,  spd:4.4, dmg:12, straw:20,  sz:0.9, color:0x440088 },
-  { id:'giant',  name:'Giant Scarecrow',        hp:700, spd:1.0, dmg:28, straw:120, sz:2.6, color:0x5c3d1e },
-  { id:'mage',   name:'Magician Scarecrow',     hp:90,  spd:2.9, dmg:14, straw:28,  sz:1,   color:0x6600cc, ranged:true, teleport:true },
-  { id:'golden', name:'Golden Scarecrow',       hp:260, spd:1.3, dmg:15, straw:200, sz:1.25,color:0xFFD700 },
-  { id:'guard',  name:'Guard Scarecrow',        hp:120, spd:2.8, dmg:13, straw:8,   sz:1.05,color:0x5c3000 },
+  { id:'basic',  name:'Basic Scarecrow',        hp:40,  spd:4.1, dmg:5,  straw:5,   sz:1,   color:0xd2b48c },
+  { id:'torch',  name:'Torch Scarecrow',        hp:60,  spd:4.9, dmg:8,  straw:10,  sz:1,   color:0xff8c00 },
+  { id:'sword',  name:'Sword Scarecrow',        hp:100, spd:3.1, dmg:15, straw:15,  sz:1,   color:0x808080 },
+  { id:'flame',  name:'Flamethrower Scarecrow', hp:80,  spd:3.6, dmg:12, straw:20,  sz:1,   color:0xff4500, ranged:true },
+  { id:'armor',  name:'Armored Scarecrow',      hp:120, spd:2.5, dmg:14, straw:30,  sz:1,   color:0x4a4a4a, armor:0.25 },
+  { id:'boss',   name:'BOSS Scarecrow',         hp:350, spd:2.5, dmg:18, straw:100, sz:1.8, color:0x8b0000 },
+  { id:'speedy', name:'Speed Demon',            hp:28,  spd:11.0,dmg:5,  straw:8,   sz:0.85,color:0xffee00 },
+  { id:'bomb',   name:'Bomb Scarecrow',         hp:90,  spd:3.2, dmg:14, straw:22,  sz:1.1, color:0x2a2a2a },
+  { id:'ice',    name:'Ice Scarecrow',          hp:75,  spd:3.1, dmg:9,  straw:18,  sz:1,   color:0x88ccff, ranged:true },
+  { id:'shadow', name:'Shadow Scarecrow',       hp:65,  spd:6.2, dmg:12, straw:20,  sz:0.9, color:0x440088 },
+  { id:'giant',  name:'Giant Scarecrow',        hp:700, spd:1.4, dmg:28, straw:120, sz:2.6, color:0x5c3d1e },
+  { id:'mage',   name:'Magician Scarecrow',     hp:90,  spd:4.1, dmg:14, straw:28,  sz:1,   color:0x6600cc, ranged:true, teleport:true },
+  { id:'golden', name:'Golden Scarecrow',       hp:260, spd:1.8, dmg:15, straw:200, sz:1.25,color:0xFFD700 },
+  { id:'guard',  name:'Guard Scarecrow',        hp:120, spd:3.9, dmg:13, straw:8,   sz:1.05,color:0x5c3000 },
 ];
 
 const WAVES = [


### PR DESCRIPTION
basic 2.9→4.1, torch 3.5→4.9, sword 2.2→3.1, flame 2.6→3.6, armor 1.8→2.5, boss 1.8→2.5, speedy 8.0→11.0, bomb 2.3→3.2, ice 2.2→3.1, shadow 4.4→6.2, giant 1.0→1.4, mage 2.9→4.1, golden 1.3→1.8, guard 2.8→3.9

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE