### PR TITLE
Move vortex suck plant from Placeables to Defenses tab

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -701,7 +701,6 @@ const PLACEABLES = [
   { id:'honeypot',   name:'Honey Pot',          emoji:'🍯', cost:25, desc:'💚 Lures & HEAVILY slows nearby enemies',    kind:'freeze', dmg:0,  range:5.0,        hp:50,  color:0xf5a623, support:true },
   { id:'crystal_plt',name:'Crystal Shard',      emoji:'💎', cost:40, desc:'⚔️ Chains lightning to 8 nearby foes',      kind:'turret', dmg:18, range:6,   cd:1.2, hp:55,  color:0x66ccff, chains:8 },
   { id:'mega_mine',  name:'Mega Mine',          emoji:'💥', cost:30, desc:'⚔️ Massive explosion — huge AoE damage',    kind:'mine',   dmg:120,range:4,   aoe:5,  hp:1,   color:0xff2200 },
-  { id:'vortex_bloom',name:'Vortex Blossom',   emoji:'🌀', cost:50, desc:'🌀 Sucks ALL enemies inward — dmg while pulling', kind:'vortex', dmg:5, range:9, pull:6, hp:75, color:0x9900cc },
 ];
 
 const DEFENSE_ITEMS = [
@@ -712,6 +711,7 @@ const DEFENSE_ITEMS = [
   { id:'bombtwr',  name:'Bomb Tower',    emoji:'💣', cost:40, desc:'AoE bomb every 3s (range 5)',          type:'bombtwr',  hp:80,  dmg:60, range:5,  cd:3.0, aoe:3 },
   { id:'spike',    name:'Spike Trap',    emoji:'🗡️', cost:15, desc:'Damages enemies walking over it',      type:'spike',    hp:80,  dmg:18, range:1.6 },
   { id:'tesla',    name:'Tesla Coil',    emoji:'⚡', cost:35, desc:'Zaps up to 4 enemies every 2s',        type:'tesla',    hp:70,  dmg:22, range:5.5, cd:2.0, chains:4 },
+  { id:'vortex_bloom', name:'Vortex Blossom', emoji:'🌀', cost:50, desc:'Sucks ALL enemies inward — deals damage while pulling', type:'vortex', dmg:5, range:9, pull:6, color:0x9900cc },
 ];
 
 const ANIMALS = [
@@ -1202,7 +1202,6 @@ const PLACEABLES_JUNGLE = [
   { id:'toxic_pool',   name:'Toxic Pool',      emoji:'☠️', cost:40, desc:'⚔️ Poison gas clouds burn enemies',    kind:'turret', dmg:18, range:7,   cd:0.9, hp:60,  color:0x44aa00, burn:6 },
   { id:'drum_totem',   name:'Drum Totem',      emoji:'🥁', cost:35, desc:'💚 Drum pulses slow nearby enemies',   kind:'freeze', dmg:0,  range:5,          hp:70,  color:0xa0522d, support:true },
   { id:'kong_cannon',  name:'Kong Cannon',     emoji:'🦍', cost:55, desc:'⚔️ Massive AoE coconut shockwave',     kind:'turret', dmg:52, range:11,  cd:4.0, hp:110, color:0x3a2010, aoe:4 },
-  { id:'whirl_fern',  name:'Whirlpool Fern',  emoji:'🌀', cost:50, desc:'🌀 Spinning vines drag all enemies inward', kind:'vortex', dmg:6, range:9, pull:7, hp:75, color:0x226600 },
   { id:'mist_cloud',   name:'Mist Sprayer',    emoji:'🌫️', cost:30, desc:'⚔️ Slow mist blasts chill enemies',   kind:'turret', dmg:8,  range:6.5, cd:1.8, hp:50,  color:0xaaddcc, slow:0.8, slowDur:4 },
   { id:'gorilla_drum', name:'Gorilla Drum',    emoji:'🥁', cost:35, desc:'💚 Beat slows ALL nearby enemies',    kind:'freeze', dmg:0,  range:5.5,        hp:75,  color:0x3a1a00, support:true },
   { id:'liana_trap',   name:'Liana Trap',      emoji:'🌿', cost:18, desc:'⚔️ Roots enemies + deals damage',    kind:'passive',dmg:14, range:1.8,        hp:65,  color:0x3a5a10, root:true },
@@ -1217,6 +1216,7 @@ const DEFENSES_JUNGLE = [
   { id:'bomb_trap',    name:'Bomb Trap',      emoji:'💣', cost:40, desc:'AoE bamboo bomb every 3s (range 5)',    type:'bombtwr',  hp:80,  dmg:65, range:5,  cd:3.0, aoe:3 },
   { id:'spike_pit',    name:'Spike Pit',      emoji:'🗡️', cost:15, desc:'Damages enemies walking over it',       type:'spike',    hp:80,  dmg:20, range:1.6 },
   { id:'net_tower',    name:'Net Tower',      emoji:'🕸️', cost:35, desc:'Zaps up to 4 enemies every 2s',        type:'tesla',    hp:70,  dmg:24, range:5.5, cd:2.0, chains:4 },
+  { id:'whirl_fern',  name:'Whirlpool Fern', emoji:'🌀', cost:50, desc:'Spinning vines drag ALL enemies inward — deals damage', type:'vortex', dmg:6, range:9, pull:7, color:0x226600 },
 ];
 const ENEMY_TYPES_JUNGLE = [
   { id:'chimp',      name:'Jungle Chimp',      hp:45,  spd:2.2, dmg:6,  straw:5,   sz:1,    color:0x7b4f2e },
@@ -1383,7 +1383,6 @@ const PLACEABLES_SNOW = [
   { id:'bliz_fan',      name:'Blizzard Fan',      emoji:'🌀', cost:30, desc:'💚 Wide fan blast slows all nearby',  kind:'freeze', dmg:0,  range:6.0,        hp:55,  color:0x99bbff, support:true },
   { id:'cryo_tower',    name:'Cryogenic Tower',   emoji:'💙', cost:55, desc:'⚔️ HARD FREEZES foes in big range',  kind:'turret', dmg:0,  range:8,   cd:4.0, hp:100, color:0x0055cc, hardFreeze:true },
   { id:'ice_mines',     name:'Ice Mine Array',    emoji:'💥', cost:35, desc:'⚔️ Ice spike eruption — huge AoE',   kind:'mine',   dmg:80, range:4,   aoe:4.5,hp:1,   color:0x88ddff },
-  { id:'frost_vortex',  name:'Frost Vortex',      emoji:'🌀', cost:50, desc:'🌀 Ice whirlwind pulls + FREEZES enemies', kind:'vortex', dmg:3, range:9, pull:5, hp:75, color:0x44ccff, slow:true },
 ];
 const DEFENSES_SNOW = [
   { id:'ice_barrier',   name:'Ice Barrier',       emoji:'🧊', cost:10, desc:'Blocks and slows enemy path',         type:'fence',    hp:70,  color:0x99ccee },
@@ -1393,6 +1392,7 @@ const DEFENSES_SNOW = [
   { id:'frost_bomb_twr',name:'Frost Bomb Tower',  emoji:'💣', cost:40, desc:'AoE ice bomb every 3s (range 5)',     type:'bombtwr',  hp:85,  dmg:62, range:5,  cd:3.0, aoe:3 },
   { id:'ice_spike',     name:'Ice Spike Trap',    emoji:'🗡️', cost:15, desc:'Damages enemies walking over it',     type:'spike',    hp:80,  dmg:20, range:1.6 },
   { id:'bliz_coil',     name:'Blizzard Coil',     emoji:'🌀', cost:35, desc:'Zaps up to 4 enemies every 2s',      type:'tesla',    hp:70,  dmg:24, range:5.5, cd:2.0, chains:4 },
+  { id:'frost_vortex',  name:'Frost Vortex',      emoji:'🌀', cost:50, desc:'Ice whirlwind pulls + FREEZES ALL enemies inward', type:'vortex', dmg:3, range:9, pull:5, slow:true, color:0x44ccff },
 ];
 const ENEMY_TYPES_SNOW = [
   { id:'snow_basic',    name:'Basic Snowman',     hp:45,  spd:1.8, dmg:5,  straw:5,   sz:1,    color:0xffffff },
@@ -1555,7 +1555,6 @@ const PLACEABLES_DEEPSEA = [
   { id:'giant_anem',   name:'Giant Anemone',      emoji:'🌸', cost:40, desc:'⚔️ Stinging tentacles chain to 4 foes', kind:'turret', dmg:20, range:4.5, cd:0.7, hp:80,  color:0xff88aa, chains:4 },
   { id:'lure_beacon',  name:'Lure Beacon',        emoji:'💡', cost:20, desc:'💚 Lures enemies toward it — slows all', kind:'passive',dmg:0,  range:8,          hp:60,  color:0xffff44, slow:0.4 },
   { id:'shark_turret', name:'Shark Fin Turret',   emoji:'🦈', cost:50, desc:'⚔️ Razor fins shred nearby enemies',    kind:'turret', dmg:38, range:6.5, cd:1.2, hp:90,  color:0x5577aa },
-  { id:'whirlpool',    name:'Whirlpool Node',     emoji:'🌀', cost:50, desc:'🌀 Powerful whirlpool drags ALL foes inward', kind:'vortex', dmg:5, range:10, pull:8, hp:75, color:0x1144bb },
 ];
 const DEFENSES_DEEPSEA = [
   { id:'kelp_wall',    name:'Kelp Wall',     emoji:'🌿', cost:10, desc:'Dense kelp — blocks enemies',                  type:'fence',    hp:70,  color:0x226633 },
@@ -1564,6 +1563,7 @@ const DEFENSES_DEEPSEA = [
   { id:'whirlpool',    name:'Whirlpool',     emoji:'🌀', cost:25, desc:'Spins + slows enemies in area',               type:'moat',     hp:999, slow:0.55, color:0x3388cc },
   { id:'ink_cloud',    name:'Ink Cloud',     emoji:'🦑', cost:15, desc:'Blinds enemies — they wander off',            type:'campfire', hp:999, dmg:2,  range:3.5, color:0x220044 },
   { id:'urchin_spike', name:'Spike Urchin',  emoji:'🦔', cost:20, desc:'Damages + slows enemies that cross',          type:'mine',     hp:999, dmg:25, range:1.5, color:0x885544 },
+  { id:'vortex_node',  name:'Whirlpool Vortex', emoji:'🌀', cost:50, desc:'Powerful whirlpool drags ALL foes inward + deals damage', type:'vortex', dmg:5, range:10, pull:8, color:0x1144bb },
 ];
 const ENEMY_TYPES_DEEPSEA = [
   { id:'clownfish',  name:'Clown Fish',      hp:35,  spd:2.8, dmg:4,  straw:4,   sz:0.8,  color:0xff6622 },
@@ -4546,20 +4546,6 @@ function updatePlacedPlants(dt) {
           }
         }
       }
-      if (p.data.kind === 'vortex') {
-        const r2 = p.data.range * p.data.range;
-        for (const e of gs.enemies) {
-          const dsq = e.pos.distanceToSquared(p.pos);
-          if (dsq > 0.25 && dsq < r2) {
-            const pullDir = p.pos.clone().sub(e.pos).setY(0).normalize();
-            e.vel.add(pullDir.multiplyScalar((p.data.pull || 5) * tdt));
-            if (p.data.dmg > 0) { e.hp -= p.data.dmg * tdt; if (e.hp <= 0) killEnemy(e); }
-            if (p.data.slow) e.slowTimer = Math.max(e.slowTimer || 0, 0.6);
-          }
-        }
-        p._vfxT = (p._vfxT || 0) - tdt;
-        if (p._vfxT <= 0) { p._vfxT = 1.0; spawnFX(p.pos.clone(), p.data.color, 0.9, p.data.range * 0.22); }
-      }
     }
 
     if (p.data.kind === 'mine') {
@@ -4813,6 +4799,20 @@ function updatePlacedPlants(dt) {
         inRange.slice(0, d.data.chains || 4).forEach(e => { dmgEnemy(e, d.data.dmg); spawnFX(e.pos.clone(), 0x88ffff, 0.3, 0.6); });
         if (inRange.length > 0) { sfxZap(); d.timer = d.data.cd; }
       }
+    }
+    if (d.data.type === 'vortex') {
+      const r2 = d.data.range * d.data.range;
+      for (const e of gs.enemies) {
+        const dsq = e.pos.distanceToSquared(d.pos);
+        if (dsq > 0.25 && dsq < r2) {
+          const pullDir = d.pos.clone().sub(e.pos).setY(0).normalize();
+          e.vel.add(pullDir.multiplyScalar((d.data.pull || 5) * dt));
+          if (d.data.dmg > 0) { e.hp -= d.data.dmg * dt; if (e.hp <= 0) killEnemy(e); }
+          if (d.data.slow) e.slowTimer = Math.max(e.slowTimer || 0, 0.6);
+        }
+      }
+      d._vfxT = (d._vfxT || 0) - dt;
+      if (d._vfxT <= 0) { d._vfxT = 1.0; spawnFX(d.pos.clone(), d.data.color || 0x8800ff, 0.9, (d.data.range || 8) * 0.22); }
     }
   });
 }


### PR DESCRIPTION
Vortex plants now appear in the Defenses shop tab for all 4 biomes:
- Garden: Vortex Blossom 🌀 (pull 6, range 9, 5 dmg/s, purple)
- Jungle: Whirlpool Fern 🌀 (pull 7, range 9, 6 dmg/s, green)
- Snow: Frost Vortex 🌀 (pull 5, range 9, 3 dmg/s + slows)
- Deep Sea: Whirlpool Vortex 🌀 (pull 8, range 10, 5 dmg/s)

Update logic moved to gs.defenses.forEach using type:'vortex' dispatch

https://claude.ai/code/session_013X7RXNF54ZSbEoYt37eqdE