### PR TITLE
Isle of Adventure: improve dialogue text readability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Isle of Adventure - Text Readability
+
+#### Changed
+- All dialogue and description text now renders on a dark semi-transparent backing panel, so it stays readable over detailed background artwork
+- Character speech is never smaller than 16px (previously as small as 13px); body text default raised from 16px to 17px
+- Dialogue choice buttons enlarged (280×60, 14px text) for easier reading and tapping
+- Dynamic texts (item checklists, quest progress) recreate their panels when they change so the backing always fits
+
 ### Battle of the Druids - Gameplay Overhaul & Polish
 
 #### Added

--- a/isle-of-adventure/js/BaseScene.js
+++ b/isle-of-adventure/js/BaseScene.js
@@ -65,9 +65,15 @@ export default class BaseScene extends Phaser.Scene {
         }).setOrigin(0.5);
     }
 
-    /** Stroked, readable body text. */
-    addText(x, y, text, size = 16, color = '#FFFFFF', extra = {}) {
-        return this.add.text(x, y, text, {
+    /**
+     * Stroked, readable body text. Prose (multiline or longer than ~40
+     * characters) automatically gets a dark backing panel so it stays
+     * readable over detailed artwork. Pass `extra.panel: true/false` to
+     * force it either way.
+     */
+    addText(x, y, text, size = 17, color = '#FFFFFF', extra = {}) {
+        const { panel, ...style } = extra;
+        const txt = this.add.text(x, y, text, {
             fontSize: `${size}px`,
             fill: color,
             fontFamily: 'Arial',
@@ -75,13 +81,33 @@ export default class BaseScene extends Phaser.Scene {
             stroke: '#000000',
             strokeThickness: 3,
             shadow: { offsetX: 1, offsetY: 2, color: '#000000', blur: 4, fill: true },
-            ...extra
+            ...style
         }).setOrigin(0.5);
+
+        const wantsPanel = panel !== undefined
+            ? panel
+            : (text.includes('\n') || text.length > 40);
+
+        if (wantsPanel) {
+            const pad = { x: 18, y: 10 };
+            const backing = this.add.rectangle(
+                x, y, txt.width + pad.x * 2, txt.height + pad.y * 2, 0x000000, 0.55
+            );
+            backing.setStrokeStyle(1, 0xFFFFFF, 0.12);
+            backing.setDepth(6);
+            txt.setDepth(6.5);
+            // The panel lives and dies with its text
+            txt.once('destroy', () => { if (backing.scene) backing.destroy(); });
+        }
+
+        return txt;
     }
 
-    /** Italic character speech. */
+    /** Italic character speech — always panelled, never below 16px. */
     addSpeech(x, y, text, color = '#FFFF99', size = 15) {
-        return this.addText(x, y, text, size, color, { fontStyle: 'italic' });
+        return this.addText(x, y, text, Math.max(size, 16), color, {
+            fontStyle: 'italic', panel: true
+        });
     }
 
     /**
@@ -130,7 +156,7 @@ export default class BaseScene extends Phaser.Scene {
      */
     createChoiceButton(x, y, text, callback, color = 0x2C5F2D, hover = 0x4A7C59) {
         return this.createButton(x, y, text, callback, {
-            width: 264, height: 56, color, hover, fontSize: 13
+            width: 280, height: 60, color, hover, fontSize: 14
         });
     }
 
@@ -214,7 +240,8 @@ export default class BaseScene extends Phaser.Scene {
 
     /** Floating pickup animation + collect feedback. */
     celebrate(x, y, text, color = '#FFD700') {
-        const msg = this.addText(x, y, text, 22, color, { fontStyle: 'bold' });
+        // No panel: this text floats upward and a static backing would be left behind
+        const msg = this.addText(x, y, text, 22, color, { fontStyle: 'bold', panel: false });
         this.tweens.add({
             targets: msg, y: y - 26, duration: 900, ease: 'Sine.easeOut'
         });

--- a/isle-of-adventure/js/scenes/HouseScene.js
+++ b/isle-of-adventure/js/scenes/HouseScene.js
@@ -37,7 +37,6 @@ export default class HouseScene extends BaseScene {
         this.createItem(800, 330, '🍞', ITEMS.FOOD.name, 'Fresh bread. Trolls are said to LOVE carbs.');
 
         // Gear checklist so players know when they're battle-ready
-        this.checklist = this.addText(SCREEN_WIDTH/2, 560, '', 15);
         this.updateChecklist();
 
         this.createButton(SCREEN_WIDTH/2, 700, 'Return to Village', () => this.goTo(SCENES.VILLAGE));
@@ -70,12 +69,14 @@ export default class HouseScene extends BaseScene {
     }
 
     updateChecklist() {
-        if (!this.checklist) return;
+        // Recreate rather than setText so the backing panel resizes with the text
+        if (this.checklist) this.checklist.destroy();
         const gear = ['Bow', 'Arrows', 'Leather Armor'].filter(i => this.gameState.hasItem(i));
-        this.checklist.setText(gear.length === 3
-            ? '⚔️ You are fully equipped for battle!'
-            : `Battle gear collected: ${gear.length} / 3 — grab it all before picking fights.`);
-        this.checklist.setFill(gear.length === 3 ? '#7CFC90' : '#FFD97A');
+        this.checklist = this.addText(SCREEN_WIDTH/2, 560,
+            gear.length === 3
+                ? '⚔️ You are fully equipped for battle!'
+                : `Battle gear collected: ${gear.length} / 3 — grab it all before picking fights.`,
+            16, gear.length === 3 ? '#7CFC90' : '#FFD97A', { panel: true });
     }
 
     collectItem(name, blurb, sprite, x, y) {

--- a/isle-of-adventure/js/scenes/VillageScene.js
+++ b/isle-of-adventure/js/scenes/VillageScene.js
@@ -54,7 +54,7 @@ export default class VillageScene extends BaseScene {
         this.addText(SCREEN_WIDTH/2, 560,
             `Sacred items found: ${collected.length} / 3` +
             (collected.length ? `  (${collected.join(', ')})` : ''),
-            14, collected.length === 3 ? '#7CFC90' : '#FFD97a');
+            15, collected.length === 3 ? '#7CFC90' : '#FFD97a', { panel: true });
 
         this.createButton(SCREEN_WIDTH/2, 700, 'Main Menu', () => this.goTo('MainMenuScene'), { width: 180 });
     }


### PR DESCRIPTION
## Summary

Dialogue and description text was hard to read — small fonts (down to 13px) rendered directly over detailed background artwork with only an outline. This PR fixes readability across all 24 scenes via the shared `BaseScene` helpers:

- **Dark semi-transparent backing panels** behind all prose and character speech (the classic adventure-game dialogue box), applied automatically for multiline/long text and always for speech — with opt-out for floating pickup messages that animate
- **Larger text**: speech is never below 16px (was as small as 13px); body text default raised 16px → 17px
- **Bigger choice buttons**: 280×60 with 14px labels (was 264×56 / 13px) — easier to read and tap
- Dynamic texts (gear checklist, quest progress) recreate their panel when content changes so the backing always fits
- Panels are cleaned up automatically when their text is destroyed (timed messages, scene sub-state changes)

## Verification

- Full automated Chromium playthrough of the entire game (~60 steps): all quest items, trinkets, locations, and foes — zero runtime errors
- Screenshots of dialogue-heavy scenes (Toll Bridge, Mountain Pass, Elven Palace) confirm text is clearly legible over busy art
- All JS syntax-checked

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012MEpxL153S97TYWJHqyosj

---
_Generated by [Claude Code](https://claude.ai/code/session_012MEpxL153S97TYWJHqyosj)_