### PR TITLE
Battle of the Druids: gameplay overhaul, bug fixes, and polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Battle of the Druids - Gameplay Overhaul & Polish
+
+#### Added
+- **Save system** — progress is saved to the browser automatically (after battles, purchases, and on every menu/map visit); the character select screen shows a "Continue: <hero> (Lv N)" button when a save exists
+- **Level-up system** — every victory now grants permanent gains (+5 max HP, +2 attack, +2 defense), shown on the victory screen; the game no longer depends on the old potion max-HP exploit to be beatable
+- **Crits and dodges** — Speed finally does something: faster fighters dodge more and crit more (Rogue gets a +10% crit bonus, matching its "critical strikes" description); crits shake the screen, misses show "MISS"
+- **Potion bag** — potions are now consumables carried into battle (bag of 5) with a "Potion (n)" button in combat, instead of instant permanent max-HP boosts; bag contents shown in the Inventory
+- **Dragon Shard revive** — shards finally have a use: on defeat you can spend 3 to revive at 50% HP and keep fighting
+- **Flee button** in battle (the old forfeit dialog was unreachable dead code)
+- **"Begin Adventure" button** on character creation (no more Enter-key-only confirmation — much friendlier on mobile)
+- Battle feel: attack lunge animations, hit flashes, idle bobbing, victory-banner pop, turn indicator colors, and dimmed action buttons during the enemy turn
+- World map: player status header (level/gold/shards/potions), pulsing markers for locations with progress left to earn, and completed locations stay open for replay so gold/shard grinding is always possible
+
+#### Changed
+- **Rebalanced the whole difficulty curve** (verified by simulated playthroughs of all four classes): enemy scaling from player victories capped at +30%, enemy attack grows at half the rate of their health/defense, boss areas toned down, enemy speed no longer scales (so late-game enemies can't out-crit any gear)
+- Healing scales with max health (25–35%, Wizard spell 35–50%) so it stays useful late game; enemy self-heals are weaker (10–15%) and enemies only heal when actually hurt instead of wasting turns at full HP
+- Fireball/Ice Shard now use the same proportional defense formula as physical attacks (they previously fell to near-zero damage against armored enemies); spell damage also scales with victories
+- Wizards passively regain 5 mana every round on top of the +8 from basic attacks
+- Store: equipped items are labeled EQUIPPED and can't be re-bought; better gold rewards from later locations
+- Dark Mage now uses the full-resolution art instead of a 72px placeholder sprite
+
+#### Fixed
+- Wizard battle buttons leaked mana-cost labels on every action (text objects stacked forever)
+- Store leaked stat texts and tier circles when switching tiers
+- Dialog boxes (quit, forfeit) left their buttons and text behind when closed with "No"
+- Background music no longer restarts from the beginning on every scene change; battle no longer tries to stop a music key that doesn't exist
+- Sentry being blocked (ad blockers) no longer throws on page load — the game boots without it
+- Scene-reuse bugs: character selection kept stale name/selection state when revisited
+- Analytics events referenced undefined `player.level` / `player.attack` fields
+
 ### Isle of Adventure - The Inland Wilds & New Artwork
 
 #### Added

--- a/battle-of-the-druids/index.html
+++ b/battle-of-the-druids/index.html
@@ -191,6 +191,9 @@
     <!-- Sentry SDK -->
     <script src="https://browser.sentry-cdn.com/8.42.0/bundle.min.js" integrity="sha384-ojBBhiQvhkfZfAhojXYPuIYW8dxzV1I8R7YJlq9Tz7T4YOZQcTuUoCgGbCz5lWAE" crossorigin="anonymous"></script>
     <script>
+        // Guard: Sentry CDN may be blocked (ad blockers, strict networks) -
+        // the game must still boot without it
+        if (typeof Sentry !== 'undefined') {
         Sentry.init({
             dsn: "https://5752f76100bc0ed5d17444652339d50f@o4509524111523840.ingest.us.sentry.io/4509524122075136",
             integrations: [
@@ -214,6 +217,7 @@
             platform: "browser",
             engine: "phaser3"
         });
+        }
     </script>
 
     <!-- Phaser.js from CDN -->
@@ -222,6 +226,7 @@
     <!-- Game modules -->
     <script src="js/GameData.js"></script>
     <script src="js/Character.js"></script>
+    <script src="js/SaveSystem.js"></script>
     <script src="js/Equipment.js"></script>
     <script src="js/Effects.js"></script>
     <script src="js/Assets.js"></script>

--- a/battle-of-the-druids/js/Assets.js
+++ b/battle-of-the-druids/js/Assets.js
@@ -36,7 +36,7 @@ class AssetManager {
         const enemies = [
             'goblin', 'orc', 'skeleton', 'banshee', 'ghost', 'vampire',
             'lich', 'dragon_whelp', 'ancient_warrior', 'ancient_guardian',
-            'assassin', 'city_guard', 'dark_mage', 'elite_dark_mage',
+            'assassin', 'city_guard', 'elite_dark_mage',
             'fire_elemental', 'divine_beast', 'celestial', 'temple_guardian',
             'spirit_monk', 'pirate', 'ghost_ship', 'sea_serpent', 'kraken_spawn',
             'minotaur', 'golem', 'magma_golem', 'lava_beast', 'war_machine',
@@ -45,6 +45,11 @@ class AssetManager {
         enemies.forEach(enemy => {
             scene.load.image(enemy, `${enemy}.png`);
         });
+
+        // dark_mage.png is a tiny 72px placeholder - use the full-res elite art
+        // instead (must not also be queued under its own name above, or Phaser
+        // keeps the first file registered for the key)
+        scene.load.image('dark_mage', 'elite_dark_mage.png');
         
         // Background images
         scene.load.image('world_map', 'world_map.png');
@@ -184,19 +189,11 @@ class AssetManager {
     // Play sound with fallback
     playSound(scene, soundName, volume = 0.5) {
         try {
-            console.log(`🔊 Attempting to play sound: ${soundName}`);
-            console.log(`🔊 Scene.sound exists:`, !!scene.sound);
-            console.log(`🔊 Available sounds:`, scene.sound ? Object.keys(scene.sound.sounds) : 'No sound manager');
-            
             if (scene.sound && scene.cache.audio.exists(soundName)) {
-                console.log(`🔊 Playing sound: ${soundName} at volume ${volume}`);
                 scene.sound.play(soundName, { volume });
                 return true;
             } else {
                 console.warn(`🔊 Sound not found or not loaded: ${soundName}`);
-                if (scene.sound) {
-                    console.warn(`🔊 Available audio keys:`, scene.cache.audio.getKeys());
-                }
             }
         } catch (error) {
             console.warn(`🔊 Could not play sound: ${soundName}`, error);
@@ -224,19 +221,23 @@ class AssetManager {
     // Play background music
     playBackgroundMusic(scene, loop = true, volume = 0.3, trackName = 'background_music') {
         try {
-            console.log(`🎵 Attempting to play background music: ${trackName}`);
-            
-            // Stop any existing background music first
+            if (!scene.sound) return null;
+
+            // If this track is already playing, keep it going instead of
+            // restarting it on every scene change
+            const existing = scene.sound.get(trackName);
+            if (existing && existing.isPlaying) {
+                existing.setVolume(volume);
+                return existing;
+            }
+
+            // Stop any other background music first
             this.stopAllMusic(scene);
-            
-            console.log(`🎵 Scene.sound exists:`, !!scene.sound);
-            console.log(`🎵 ${trackName} exists:`, scene.cache.audio.exists(trackName));
-            
-            if (scene.sound && scene.cache.audio.exists(trackName)) {
-                console.log(`🎵 Playing ${trackName} at volume ${volume}`);
-                const music = scene.sound.play(trackName, { 
-                    loop, 
-                    volume 
+
+            if (scene.cache.audio.exists(trackName)) {
+                const music = scene.sound.play(trackName, {
+                    loop,
+                    volume
                 });
                 return music;
             } else {

--- a/battle-of-the-druids/js/Character.js
+++ b/battle-of-the-druids/js/Character.js
@@ -42,6 +42,7 @@ class Character {
         this.armorBonus = 0;
         this.accessoryBonus = 0;
         this.locationVictories = {};
+        this.potions = []; // Consumables carried into battle
         
         // Equipment system
         if (!isEnemy) {
@@ -147,39 +148,98 @@ class Character {
         return this.baseSpeed + this.accessoryBonus;
     }
     
+    getDodgeChance(attacker) {
+        const combat = GAME_CONSTANTS.COMBAT;
+        const speedEdge = this.getTotalSpeed() - attacker.getTotalSpeed();
+        return Math.max(0, Math.min(combat.DODGE_CHANCE_CAP, speedEdge * combat.DODGE_SPEED_FACTOR));
+    }
+
+    getCritChance(defender) {
+        const combat = GAME_CONSTANTS.COMBAT;
+        const speedEdge = this.getTotalSpeed() - defender.getTotalSpeed();
+        let chance = combat.CRIT_BASE_CHANCE + Math.max(0, speedEdge * combat.CRIT_SPEED_FACTOR);
+        if (this.charType === CharacterType.ROGUE) {
+            chance += combat.ROGUE_CRIT_BONUS;
+        }
+        return Math.min(combat.CRIT_CHANCE_CAP, chance);
+    }
+
+    // Shared damage roll for basic and special attacks.
+    // Returns { damage, crit, dodged } so the UI can show misses and crits.
+    dealDamage(enemy, multiplier = 1.0) {
+        if (Math.random() < enemy.getDodgeChance(this)) {
+            return { damage: 0, crit: false, dodged: true };
+        }
+
+        const baseDamage = Math.floor(this.getTotalAttack() * multiplier);
+        const damageRange = Math.floor(baseDamage * 0.2);
+        let damage = Math.floor(Math.random() * (2 * damageRange + 1)) + baseDamage - damageRange;
+
+        const crit = Math.random() < this.getCritChance(enemy);
+        if (crit) {
+            damage = Math.floor(damage * GAME_CONSTANTS.COMBAT.CRIT_MULTIPLIER);
+        }
+
+        // Defense reduces damage proportionally, with a floor so hits always matter
+        const defenseReduction = enemy.getTotalDefense() / (enemy.getTotalDefense() + 150);
+        let finalDamage = Math.floor(damage * (1 - defenseReduction));
+        finalDamage = Math.max(Math.floor(damage * GAME_CONSTANTS.SCALING.MIN_DAMAGE_PERCENT), finalDamage);
+
+        enemy.health = Math.max(0, enemy.health - finalDamage);
+        return { damage: finalDamage, crit, dodged: false };
+    }
+
     attackEnemy(enemy) {
-        const baseDamage = this.getTotalAttack();
-        const damageRange = Math.floor(baseDamage * 0.2);
-        const damage = Math.floor(Math.random() * (2 * damageRange + 1)) + baseDamage - damageRange;
-        
-        // Balanced damage calculation: defense reduces damage but not too much
-        const defenseReduction = enemy.getTotalDefense() / (enemy.getTotalDefense() + 150); // Increased from 100 to 150
-        let finalDamage = Math.floor(damage * (1 - defenseReduction));
-        finalDamage = Math.max(Math.floor(damage * 0.4), finalDamage); // Minimum 40% damage (increased from 25%)
-        
-        enemy.health = Math.max(0, enemy.health - finalDamage);
-        return finalDamage;
+        return this.dealDamage(enemy, 1.0);
     }
-    
+
     specialAttack(enemy) {
-        const baseDamage = Math.floor(this.getTotalAttack() * 1.5);
-        const damageRange = Math.floor(baseDamage * 0.2);
-        const damage = Math.floor(Math.random() * (2 * damageRange + 1)) + baseDamage - damageRange;
-        
-        // Balanced damage calculation: defense reduces damage but not too much
-        const defenseReduction = enemy.getTotalDefense() / (enemy.getTotalDefense() + 150); // Increased from 100 to 150
-        let finalDamage = Math.floor(damage * (1 - defenseReduction));
-        finalDamage = Math.max(Math.floor(damage * 0.4), finalDamage); // Minimum 40% damage (increased from 25%)
-        
-        enemy.health = Math.max(0, enemy.health - finalDamage);
-        return finalDamage;
+        return this.dealDamage(enemy, 1.5);
     }
-    
+
     heal() {
-        const healAmount = Math.floor(Math.random() * 16) + 25; // 25-40
+        // Percentage-based so healing stays relevant as max health grows.
+        // Enemies heal a smaller share so boss fights don't stall out.
+        const healing = GAME_CONSTANTS.HEALING;
+        const minPercent = this.isEnemy ? 0.10 : healing.HEAL_PERCENT_MIN;
+        const maxPercent = this.isEnemy ? 0.15 : healing.HEAL_PERCENT_MAX;
+        const percent = minPercent + Math.random() * (maxPercent - minPercent);
+        const healAmount = Math.max(healing.MIN_HEAL, Math.floor(this.maxHealth * percent));
         const oldHealth = this.health;
         this.health = Math.min(this.maxHealth, this.health + healAmount);
         return this.health - oldHealth;
+    }
+
+    // Permanent stat gains earned with each victory
+    applyVictoryGains() {
+        const gains = GAME_CONSTANTS.LEVEL_UP;
+        this.maxHealth += gains.HEALTH_PER_VICTORY;
+        this.health = Math.min(this.maxHealth, this.health + gains.HEALTH_PER_VICTORY);
+        this.baseAttack += gains.ATTACK_PER_VICTORY;
+        this.baseDefense += gains.DEFENSE_PER_VICTORY;
+        return gains;
+    }
+
+    hasPotions() {
+        return this.potions && this.potions.length > 0;
+    }
+
+    // Drinks the weakest potion in the bag (saves the strong ones for emergencies)
+    usePotion() {
+        if (!this.hasPotions()) return null;
+
+        let weakestIdx = 0;
+        this.potions.forEach((potion, idx) => {
+            if (potion.healPercent < this.potions[weakestIdx].healPercent) {
+                weakestIdx = idx;
+            }
+        });
+
+        const potion = this.potions.splice(weakestIdx, 1)[0];
+        const healAmount = Math.max(1, Math.floor(this.maxHealth * potion.healPercent / 100));
+        const oldHealth = this.health;
+        this.health = Math.min(this.maxHealth, this.health + healAmount);
+        return { name: potion.name, healed: this.health - oldHealth };
     }
     
     castSpell(spellKey, enemy) {
@@ -209,39 +269,39 @@ class Character {
         
         // Calculate damage/effect
         if (spell.specialEffect === "heal") {
-            // Healing spell
-            const healAmount = Math.floor(Math.random() * 21) + 40; // 40-60
+            // Healing spell scales with max health
+            const healing = GAME_CONSTANTS.HEALING;
+            const percent = healing.WIZARD_HEAL_PERCENT_MIN + Math.random() * (healing.WIZARD_HEAL_PERCENT_MAX - healing.WIZARD_HEAL_PERCENT_MIN);
+            const healAmount = Math.max(healing.MIN_HEAL, Math.floor(this.maxHealth * percent));
             const oldHealth = this.health;
             this.health = Math.min(this.maxHealth, this.health + healAmount);
             const actualHeal = this.health - oldHealth;
             return { damage: actualHeal, effect: "heal" };
         } else {
-            // Damage spell
-            const baseDamage = spell.damageBase + this.weaponBonus;
+            // Damage spell - scales with weapon bonus and victories so spells stay strong late game
+            const baseDamage = spell.damageBase + this.weaponBonus + this.victories * 2;
             const variance = Math.floor(baseDamage * spell.damageVariance);
             const damage = Math.floor(Math.random() * (2 * variance + 1)) + baseDamage - variance;
-            
+
             let finalDamage;
-            
-            // Apply spell effects
+
             if (spell.specialEffect === "pierce") {
                 // Lightning bolt - ignores armor
                 finalDamage = damage;
-            } else if (spell.specialEffect === "fire") {
-                // Fireball - normal damage calculation
-                finalDamage = Math.max(1, damage - enemy.getTotalDefense());
-            } else if (spell.specialEffect === "freeze") {
-                // Ice shard - normal damage + chance to freeze
-                finalDamage = Math.max(1, damage - enemy.getTotalDefense());
-                // Check for freeze effect
-                if (Math.random() < (spell.effectChance || 0)) {
-                    enemy.frozenTurns = 2; // Skip 2 turns
-                    return { damage: finalDamage, effect: "freeze" };
-                }
             } else {
-                finalDamage = Math.max(1, damage - enemy.getTotalDefense());
+                // Fire/ice use the same proportional defense formula as physical
+                // attacks, so they don't fall off a cliff against armored enemies
+                const defenseReduction = enemy.getTotalDefense() / (enemy.getTotalDefense() + 150);
+                finalDamage = Math.floor(damage * (1 - defenseReduction));
+                finalDamage = Math.max(Math.floor(damage * GAME_CONSTANTS.SCALING.MIN_DAMAGE_PERCENT), finalDamage);
             }
-            
+
+            if (spell.specialEffect === "freeze" && Math.random() < (spell.effectChance || 0)) {
+                enemy.frozenTurns = 2; // Skip 2 turns
+                enemy.health = Math.max(0, enemy.health - finalDamage);
+                return { damage: finalDamage, effect: "freeze" };
+            }
+
             // Apply damage
             enemy.health = Math.max(0, enemy.health - finalDamage);
             return { damage: finalDamage, effect: spell.specialEffect };
@@ -285,10 +345,12 @@ function createEnemy(enemyType, playerVictories = 0, locationName = "Arena") {
     }
     
     const baseStats = ENEMY_STATS[enemyType] || { health: 80, attack: 70, defense: 35, speed: 65 };
-    
-    // Scale based on player victories (reduced scaling for better balance)
-    const scaleFactor = 1.0 + (playerVictories * 0.03); // Reduced from 0.05 to 0.03
-    
+
+    // Scale based on player victories, capped so grinding can't make enemies unbeatable
+    const scaling = GAME_CONSTANTS.SCALING;
+    const victoryBonus = Math.min(playerVictories * scaling.ENEMY_VICTORY_MULTIPLIER, scaling.ENEMY_VICTORY_CAP);
+    const scaleFactor = 1.0 + victoryBonus;
+
     // Location-based scaling
     const locationMultipliers = {
         "Arena": 1.0,
@@ -298,20 +360,24 @@ function createEnemy(enemyType, playerVictories = 0, locationName = "Arena") {
         "Ancient City": 1.4,
         "Sacred Shrine": 1.5,
         "Volcanic Caves": 1.6,
-        "Battle of Druids Castle": 2.0,
-        "Bot Attack": 2.0
+        "Battle of Druids Castle": 1.5,
+        "Bot Attack": 1.6
     };
-    
+
     const locationScale = locationMultipliers[locationName] || 1.0;
     const finalScale = scaleFactor * locationScale;
-    
+    // Attack grows slower than health/defense so late-game hits stay survivable
+    const attackScale = 1.0 + (finalScale - 1.0) * scaling.ENEMY_ATTACK_DAMPENING;
+
     // Create enemy with scaled stats
     const enemy = new Character(CharacterType.ENEMY, enemyType.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase()), true, enemyType);
     enemy.maxHealth = Math.floor(baseStats.health * finalScale);
     enemy.health = enemy.maxHealth;
-    enemy.baseAttack = Math.floor(baseStats.attack * finalScale);
+    enemy.baseAttack = Math.floor(baseStats.attack * attackScale);
     enemy.baseDefense = Math.floor(baseStats.defense * finalScale);
-    enemy.baseSpeed = Math.floor(baseStats.speed * finalScale);
-    
+    // Speed is never scaled - it feeds crit/dodge, and scaling it would let
+    // late-game enemies out-crit the player no matter what gear they wear
+    enemy.baseSpeed = baseStats.speed;
+
     return enemy;
 }

--- a/battle-of-the-druids/js/Equipment.js
+++ b/battle-of-the-druids/js/Equipment.js
@@ -46,26 +46,36 @@ class Store {
     }
     
     static purchaseItem(player, item) {
-        if (player.gold < item.price) {
-            return { success: false, message: "Not enough gold!" };
-        }
-        
-        player.gold -= item.price;
-        
         // Handle equipment vs consumables
         if (item.slot) {
-            // Equipment item - equip it
+            const currentItem = player.getEquippedItem(item.slot);
+            if (currentItem && currentItem.name === item.name) {
+                return { success: false, message: `${item.name} is already equipped!` };
+            }
+            if (player.gold < item.price) {
+                return { success: false, message: "Not enough gold!" };
+            }
+            player.gold -= item.price;
             const equipment = new Equipment(item);
             player.equipItem(equipment);
             return { success: true, message: `Equipped ${item.name}!` };
-        } else {
-            // Consumable item
-            if (item.health) {
-                player.maxHealth += item.health;
-                player.health += item.health;
-                return { success: true, message: `Used ${item.name}! +${item.health} max health!` };
+        } else if (item.healPercent) {
+            // Potion - goes into the bag for use during battle
+            if (!player.potions) player.potions = [];
+            if (player.potions.length >= GAME_CONSTANTS.POTIONS.BAG_LIMIT) {
+                return { success: false, message: `Potion bag is full! (${GAME_CONSTANTS.POTIONS.BAG_LIMIT} max)` };
             }
-            // Handle other consumable effects here
+            if (player.gold < item.price) {
+                return { success: false, message: "Not enough gold!" };
+            }
+            player.gold -= item.price;
+            player.potions.push({ name: item.name, healPercent: item.healPercent });
+            return { success: true, message: `${item.name} added to your bag! (${player.potions.length}/${GAME_CONSTANTS.POTIONS.BAG_LIMIT})` };
+        } else {
+            if (player.gold < item.price) {
+                return { success: false, message: "Not enough gold!" };
+            }
+            player.gold -= item.price;
             return { success: true, message: `Purchased ${item.name}!` };
         }
     }

--- a/battle-of-the-druids/js/GameData.js
+++ b/battle-of-the-druids/js/GameData.js
@@ -22,20 +22,45 @@ const GAME_CONSTANTS = {
         ANIMATION_DELAY: 30
     },
     SCALING: {
-        ENEMY_VICTORY_MULTIPLIER: 0.05,
-        DEFENSE_REDUCTION_CAP: 0.75,
-        MIN_DAMAGE_PERCENT: 0.25
+        // Enemies get 2% stronger per player victory, capped at +30%
+        ENEMY_VICTORY_MULTIPLIER: 0.02,
+        ENEMY_VICTORY_CAP: 0.30,
+        // Enemy attack grows at half the rate of their health/defense
+        ENEMY_ATTACK_DAMPENING: 0.5,
+        MIN_DAMAGE_PERCENT: 0.4
     },
     HEALING: {
-        MIN_HEAL: 25,
-        MAX_HEAL: 40,
-        WIZARD_MIN_HEAL: 40,
-        WIZARD_MAX_HEAL: 60
+        // Heals scale with max health so they stay useful late game
+        HEAL_PERCENT_MIN: 0.25,
+        HEAL_PERCENT_MAX: 0.35,
+        WIZARD_HEAL_PERCENT_MIN: 0.35,
+        WIZARD_HEAL_PERCENT_MAX: 0.50,
+        MIN_HEAL: 25
     },
     MANA: {
-        REGENERATION_PER_TURN: 10,
+        REGEN_PER_TURN: 5,
+        REGEN_ON_ATTACK: 8,
         WIZARD_MAX_MANA: 100
     },
+    COMBAT: {
+        CRIT_BASE_CHANCE: 0.05,
+        CRIT_SPEED_FACTOR: 0.0015,
+        CRIT_CHANCE_CAP: 0.35,
+        CRIT_MULTIPLIER: 1.6,
+        ROGUE_CRIT_BONUS: 0.10,
+        DODGE_SPEED_FACTOR: 0.002,
+        DODGE_CHANCE_CAP: 0.15
+    },
+    LEVEL_UP: {
+        // Permanent gains per victory
+        HEALTH_PER_VICTORY: 5,
+        ATTACK_PER_VICTORY: 2,
+        DEFENSE_PER_VICTORY: 2
+    },
+    POTIONS: {
+        BAG_LIMIT: 5
+    },
+    REVIVE_SHARD_COST: 3,
     UI: {
         CHARACTER_SIZE: 120,
         BUTTON_WIDTH: 120,
@@ -209,9 +234,9 @@ const STORE_ITEMS = {
         {
             name: "Health Potion",
             type: "consumable",
-            health: 20,
+            healPercent: 30,
             price: 25,
-            description: "Restores health"
+            description: "Restores 30% health in battle"
         }
     ],
     [ItemTier.INTERMEDIATE]: [
@@ -251,9 +276,9 @@ const STORE_ITEMS = {
         {
             name: "Magic Elixir",
             type: "consumable",
-            health: 40,
+            healPercent: 45,
             price: 60,
-            description: "Magical healing potion"
+            description: "Restores 45% health in battle"
         }
     ],
     [ItemTier.ADVANCED]: [
@@ -293,9 +318,9 @@ const STORE_ITEMS = {
         {
             name: "Greater Healing Potion",
             type: "consumable",
-            health: 60,
+            healPercent: 60,
             price: 120,
-            description: "Powerful healing elixir"
+            description: "Restores 60% health in battle"
         }
     ],
     [ItemTier.LEGENDARY]: [
@@ -335,9 +360,9 @@ const STORE_ITEMS = {
         {
             name: "Phoenix Tears",
             type: "consumable",
-            health: 100,
+            healPercent: 80,
             price: 250,
-            description: "Legendary healing essence"
+            description: "Restores 80% health in battle"
         }
     ],
     [ItemTier.MYTHIC]: [
@@ -377,9 +402,9 @@ const STORE_ITEMS = {
         {
             name: "Ambrosia",
             type: "consumable",
-            health: 150,
+            healPercent: 100,
             price: 500,
-            description: "Food of the gods"
+            description: "Fully restores health in battle"
         }
     ]
 };
@@ -521,12 +546,12 @@ const ENEMY_STATS = {
     lost_soul: { health: 70, attack: 80, defense: 15, speed: 85 },
     
     // Castle (Boss area)
-    druid_lord: { health: 200, attack: 110, defense: 55, speed: 80 },
-    ancient_guardian: { health: 180, attack: 95, defense: 60, speed: 65 },
-    
+    druid_lord: { health: 200, attack: 100, defense: 55, speed: 80 },
+    ancient_guardian: { health: 180, attack: 90, defense: 60, speed: 65 },
+
     // Bot Attack (Special area)
-    mech_dragon: { health: 220, attack: 120, defense: 50, speed: 70 },
-    war_machine: { health: 200, attack: 100, defense: 65, speed: 50 }
+    mech_dragon: { health: 220, attack: 105, defense: 50, speed: 70 },
+    war_machine: { health: 200, attack: 95, defense: 65, speed: 50 }
 };
 
 // Enemy dialogue for battle starts (kid-friendly)

--- a/battle-of-the-druids/js/SaveSystem.js
+++ b/battle-of-the-druids/js/SaveSystem.js
@@ -1,0 +1,115 @@
+/*
+ * Battle of the Druids - Web Edition
+ * SaveSystem.js
+ *
+ * Copyright (c) 2025 TitanBlade Games
+ *
+ * This file is part of Battle of the Druids, licensed under the MIT License.
+ * See LICENSE file in the project root for full license information.
+ *
+ * https://github.com/sunstar2423/titanblade-games
+ */
+
+// Persists the player's hero to localStorage so progress survives page reloads.
+const SaveSystem = {
+    SAVE_KEY: 'bod_save_v1',
+
+    isAvailable() {
+        try {
+            const testKey = '__bod_test__';
+            window.localStorage.setItem(testKey, '1');
+            window.localStorage.removeItem(testKey);
+            return true;
+        } catch (error) {
+            return false;
+        }
+    },
+
+    save(player) {
+        if (!player || player.isEnemy || !this.isAvailable()) return false;
+
+        try {
+            const data = {
+                version: 1,
+                savedAt: Date.now(),
+                charType: player.charType,
+                name: player.name,
+                victories: player.victories,
+                gold: player.gold,
+                dragonShards: player.dragonShards,
+                locationVictories: player.locationVictories,
+                maxHealth: player.maxHealth,
+                health: player.health,
+                baseAttack: player.baseAttack,
+                baseDefense: player.baseDefense,
+                baseSpeed: player.baseSpeed,
+                mana: player.mana,
+                maxMana: player.maxMana,
+                equipped: player.equipped,
+                potions: player.potions
+            };
+            window.localStorage.setItem(this.SAVE_KEY, JSON.stringify(data));
+            return true;
+        } catch (error) {
+            console.warn('💾 Failed to save game:', error);
+            return false;
+        }
+    },
+
+    // Returns raw save data (for menu preview) or null
+    peek() {
+        if (!this.isAvailable()) return null;
+
+        try {
+            const raw = window.localStorage.getItem(this.SAVE_KEY);
+            if (!raw) return null;
+            const data = JSON.parse(raw);
+            if (!data || !data.charType || !CHARACTER_PRESETS[data.charType]) return null;
+            return data;
+        } catch (error) {
+            console.warn('💾 Failed to read save:', error);
+            return null;
+        }
+    },
+
+    // Rebuilds a Character instance from a save
+    load() {
+        const data = this.peek();
+        if (!data) return null;
+
+        try {
+            const player = new Character(data.charType, data.name || 'Hero');
+            player.victories = data.victories || 0;
+            player.gold = typeof data.gold === 'number' ? data.gold : 150;
+            player.dragonShards = data.dragonShards || 0;
+            player.locationVictories = data.locationVictories || {};
+            player.maxHealth = data.maxHealth || player.maxHealth;
+            player.health = Math.min(player.maxHealth, data.health || player.maxHealth);
+            player.baseAttack = data.baseAttack || player.baseAttack;
+            player.baseDefense = data.baseDefense || player.baseDefense;
+            player.baseSpeed = data.baseSpeed || player.baseSpeed;
+            player.maxMana = data.maxMana || player.maxMana;
+            player.mana = Math.min(player.maxMana, typeof data.mana === 'number' ? data.mana : player.maxMana);
+            if (data.equipped) {
+                player.equipped = data.equipped;
+                player.updateEquipmentBonuses();
+            }
+            player.potions = Array.isArray(data.potions) ? data.potions : [];
+            return player;
+        } catch (error) {
+            console.warn('💾 Failed to load save:', error);
+            return null;
+        }
+    },
+
+    clear() {
+        if (!this.isAvailable()) return;
+        try {
+            window.localStorage.removeItem(this.SAVE_KEY);
+        } catch (error) {
+            console.warn('💾 Failed to clear save:', error);
+        }
+    }
+};
+
+window.SaveSystem = SaveSystem;

--- a/battle-of-the-druids/js/scenes/BattleScene.js
+++ b/battle-of-the-druids/js/scenes/BattleScene.js
@@ -66,12 +66,12 @@ class BattleScene extends Phaser.Scene {
         // Track battle started
         const battleStartData = {
             playerClass: this.player.charType,
-            playerLevel: this.player.level,
+            playerLevel: this.player.victories + 1,
             playerVictories: this.player.victories,
             locationName: this.location.name,
             enemyType: randomEnemyType,
             enemyName: this.enemy.name,
-            enemyLevel: this.enemy.level,
+            enemyMaxHealth: this.enemy.maxHealth,
             playerHealth: this.player.health,
             playerMaxHealth: this.player.maxHealth,
             playerMana: this.player.mana || 0,
@@ -150,10 +150,10 @@ class BattleScene extends Phaser.Scene {
         
         // Clean up battle buttons
         if (this.battleButtons) {
-            this.battleButtons.forEach(button => {
-                if (button && button.destroy) {
-                    button.destroy();
-                }
+            this.battleButtons.forEach(btn => {
+                if (btn.rect) btn.rect.destroy();
+                if (btn.text) btn.text.destroy();
+                if (btn.label) btn.label.destroy();
             });
             this.battleButtons = [];
         }
@@ -164,9 +164,10 @@ class BattleScene extends Phaser.Scene {
             this.effectManager = null;
         }
         
-        // Stop any background music
-        if (this.sound && this.sound.get('background_music')) {
-            this.sound.get('background_music').stop();
+        // Stop the finale fanfare if it's still playing (world music is shared
+        // with the world map, so leave it running for a seamless transition)
+        if (this.sound && this.sound.get('victory-fanfare')) {
+            this.sound.get('victory-fanfare').stop();
         }
         
         // Clear references
@@ -206,83 +207,85 @@ class BattleScene extends Phaser.Scene {
     
     createBattleButtons() {
         const { width, height } = this.scale;
-        
-        // Clear existing buttons
+
+        // Clear existing buttons (including any extra labels like mana costs,
+        // which previously leaked a new text object on every rebuild)
         this.battleButtons.forEach(btn => {
             if (btn.rect) btn.rect.destroy();
             if (btn.text) btn.text.destroy();
+            if (btn.label) btn.label.destroy();
         });
         this.battleButtons = [];
-        
+
+        const potionCount = this.player.potions ? this.player.potions.length : 0;
+        let buttonDefs;
+
         if (this.player.charType === CharacterType.WIZARD) {
-            // Wizard spell buttons
-            const spellButtons = [
-                { text: 'Attack', action: () => this.playerAttack(), x: 120, key: null },
+            buttonDefs = [
+                { text: 'Attack', action: () => this.playerAttack(), x: 120 },
                 { text: 'Fireball', action: () => this.castSpell('fireball'), x: 270, key: 'fireball' },
                 { text: 'Ice Shard', action: () => this.castSpell('iceShard'), x: 420, key: 'iceShard' },
                 { text: 'Lightning', action: () => this.castSpell('lightningBolt'), x: 570, key: 'lightningBolt' },
-                { text: 'Heal', action: () => this.castSpell('arcaneHealing'), x: 720, key: 'arcaneHealing' }
+                { text: 'Heal', action: () => this.castSpell('arcaneHealing'), x: 720, key: 'arcaneHealing' },
+                { text: `Potion (${potionCount})`, action: () => this.playerUsePotion(), x: 870, enabled: potionCount > 0 }
             ];
-            
-            spellButtons.forEach((btn, index) => {
-                const canCast = !btn.key || this.player.canCastSpell(btn.key);
-                const buttonColor = canCast ? COLORS.DARK_GRAY : 0x2a2a2a;
-                const textColor = canCast ? '#FFFFFF' : '#666666';
-                
-                const button = this.add.rectangle(btn.x, height - 150, 120, 40, buttonColor)
-                    .setStrokeStyle(2, COLORS.WHITE);
-                
-                const buttonText = this.add.text(btn.x, height - 150, btn.text, {
-                    fontSize: '16px',
-                    fontFamily: 'Arial',
-                    fill: textColor
-                }).setOrigin(0.5);
-                
-                if (canCast) {
-                    button.setInteractive();
-                    button.on('pointerdown', btn.action);
-                    button.on('pointerover', () => button.setFillStyle(COLORS.GRAY));
-                    button.on('pointerout', () => button.setFillStyle(COLORS.DARK_GRAY));
-                }
-                
-                // Show mana cost for spells
-                if (btn.key && WIZARD_SPELLS[btn.key]) {
-                    const spell = WIZARD_SPELLS[btn.key];
-                    this.add.text(btn.x, height - 125, `${spell.manaCost}MP`, {
-                        fontSize: '12px',
-                        fontFamily: 'Arial',
-                        fill: '#40E0D0'
-                    }).setOrigin(0.5);
-                }
-                
-                this.battleButtons.push({ rect: button, text: buttonText, key: btn.key });
-            });
         } else {
-            // Regular character buttons
-            const regularButtons = [
+            buttonDefs = [
                 { text: 'Attack', action: () => this.playerAttack(), x: 200 },
                 { text: 'Special', action: () => this.playerSpecialAttack(), x: 400 },
-                { text: 'Heal', action: () => this.playerHeal(), x: 600 }
+                { text: 'Heal', action: () => this.playerHeal(), x: 600 },
+                { text: `Potion (${potionCount})`, action: () => this.playerUsePotion(), x: 800, enabled: potionCount > 0 }
             ];
-            
-            regularButtons.forEach(btn => {
-                const button = this.add.rectangle(btn.x, height - 150, 120, 40, COLORS.DARK_GRAY)
-                    .setStrokeStyle(2, COLORS.WHITE)
-                    .setInteractive();
-                
-                const buttonText = this.add.text(btn.x, height - 150, btn.text, {
-                    fontSize: '18px',
-                    fontFamily: 'Arial',
-                    fill: '#FFFFFF'
-                }).setOrigin(0.5);
-                
+        }
+
+        buttonDefs.forEach(btn => {
+            const canUse = (btn.enabled !== false) && (!btn.key || this.player.canCastSpell(btn.key));
+            const buttonColor = canUse ? COLORS.DARK_GRAY : 0x2a2a2a;
+            const textColor = canUse ? '#FFFFFF' : '#666666';
+
+            const button = this.add.rectangle(btn.x, height - 150, 130, 40, buttonColor)
+                .setStrokeStyle(2, canUse ? COLORS.WHITE : COLORS.GRAY);
+
+            const buttonText = this.add.text(btn.x, height - 150, btn.text, {
+                fontSize: '16px',
+                fontFamily: 'Arial',
+                fill: textColor
+            }).setOrigin(0.5);
+
+            if (canUse) {
+                button.setInteractive();
                 button.on('pointerdown', btn.action);
                 button.on('pointerover', () => button.setFillStyle(COLORS.GRAY));
                 button.on('pointerout', () => button.setFillStyle(COLORS.DARK_GRAY));
-                
-                this.battleButtons.push({ rect: button, text: buttonText });
-            });
-        }
+            }
+
+            // Show mana cost for spells
+            let label = null;
+            if (btn.key && WIZARD_SPELLS[btn.key]) {
+                const spell = WIZARD_SPELLS[btn.key];
+                label = this.add.text(btn.x, height - 125, `${spell.manaCost}MP`, {
+                    fontSize: '12px',
+                    fontFamily: 'Arial',
+                    fill: '#40E0D0'
+                }).setOrigin(0.5);
+            }
+
+            this.battleButtons.push({ rect: button, text: buttonText, label, key: btn.key });
+        });
+
+        // Flee button (bottom-right corner, away from the action row)
+        const fleeBtn = this.add.rectangle(width - 90, height - 60, 120, 36, 0x5a1f1f)
+            .setStrokeStyle(2, COLORS.WHITE)
+            .setInteractive();
+        const fleeText = this.add.text(width - 90, height - 60, 'Flee', {
+            fontSize: '16px',
+            fontFamily: 'Arial',
+            fill: '#FFFFFF'
+        }).setOrigin(0.5);
+        fleeBtn.on('pointerdown', () => this.forfeitBattle());
+        fleeBtn.on('pointerover', () => fleeBtn.setFillStyle(0x803030));
+        fleeBtn.on('pointerout', () => fleeBtn.setFillStyle(0x5a1f1f));
+        this.battleButtons.push({ rect: fleeBtn, text: fleeText, label: null, alwaysOn: true });
     }
     
     createHealthBars() {
@@ -404,15 +407,56 @@ class BattleScene extends Phaser.Scene {
     
     createCharacterDisplays() {
         const { width, height } = this.scale;
-        
-        // Initialize asset manager for this scene
-        this.assetManager = new AssetManager(this);
-        
+
         // Player character (left side)
         this.playerImage = this.assetManager.getCharacterImage(this, this.player.charType.toLowerCase(), 300, 350, 180);
-        
+
         // Enemy character (right side)
         this.enemyImage = this.assetManager.getEnemyImage(this, this.enemy.name, width - 300, 350, 180);
+
+        // Gentle idle bob so the battlefield doesn't feel static
+        [this.playerImage, this.enemyImage].forEach(sprite => {
+            this.tweens.add({
+                targets: sprite,
+                y: sprite.y - 8,
+                duration: 1200,
+                yoyo: true,
+                repeat: -1,
+                ease: 'Sine.easeInOut'
+            });
+        });
+    }
+
+    // Lunge the attacker toward the target and flash the target red
+    playAttackAnimation(attackerSprite, targetSprite, direction = 1) {
+        if (attackerSprite) {
+            this.tweens.add({
+                targets: attackerSprite,
+                x: attackerSprite.x + 60 * direction,
+                duration: 120,
+                yoyo: true,
+                ease: 'Power2'
+            });
+        }
+        this.flashSprite(targetSprite);
+    }
+
+    flashSprite(sprite) {
+        if (!sprite) return;
+        if (sprite.setTint) {
+            sprite.setTint(0xFF6666);
+            this.time.delayedCall(180, () => {
+                if (sprite.active && sprite.clearTint) sprite.clearTint();
+            });
+        } else {
+            // Shape fallback (no tint support) - quick alpha blink
+            this.tweens.add({
+                targets: sprite,
+                alpha: 0.4,
+                duration: 90,
+                yoyo: true
+            });
+        }
     }
     
     drawWeaponIndicator(x, y, character) {
@@ -441,19 +485,19 @@ class BattleScene extends Phaser.Scene {
         
         // Play attack sound (higher volume for custom MP3)
         this.assetManager.playSound(this, 'attack', 0.9);
-        
-        const damage = this.player.attackEnemy(this.enemy);
-        this.effectManager.addDamageNumber(this.scale.width - 300, 350, damage);
-        this.effectManager.addAttackEffect(this.scale.width - 300, 350, 'slash');
-        
+
+        const result = this.player.attackEnemy(this.enemy);
+        this.showAttackResult(this.scale.width - 300, 350, result, 'slash');
+        this.playAttackAnimation(this.playerImage, result.dodged ? null : this.enemyImage, 1);
+
         // Track player attack
         const attackData = {
             actionType: 'attack',
-            damage: damage,
+            damage: result.damage,
             playerClass: this.player.charType,
             enemyType: this.enemy.enemyType || this.enemy.name,
             enemyHealthRemaining: this.enemy.health,
-            isCritical: damage > this.player.attack * 1.5 // Estimate critical hit
+            isCritical: result.crit
         };
         
         if (typeof trackGameEvent !== 'undefined') {
@@ -462,7 +506,7 @@ class BattleScene extends Phaser.Scene {
         
         if (typeof Sentry !== 'undefined') {
             Sentry.addBreadcrumb({
-                message: `Player attacked for ${damage} damage`,
+                message: `Player attacked for ${result.damage} damage`,
                 category: 'battle_action',
                 level: 'info',
                 data: attackData
@@ -471,52 +515,97 @@ class BattleScene extends Phaser.Scene {
         
         this.playerTurn = false;
         this.turnTimer = 60;
-        this.player.regenerateMana(8); // Increased from 5 to 8 for better mana economy
-        
+        this.player.regenerateMana(GAME_CONSTANTS.MANA.REGEN_ON_ATTACK);
+
         this.updateUI();
         this.checkBattleEnd();
     }
-    
+
     playerSpecialAttack() {
         if (!this.playerTurn || this.turnTimer > 0 || this.battleOver) return;
-        
+
         // Play special attack sound
         this.assetManager.playSound(this, 'special', 0.7);
-        
-        const damage = this.player.specialAttack(this.enemy);
-        this.effectManager.addDamageNumber(this.scale.width - 300, 350, damage, true);
-        
+
+        const result = this.player.specialAttack(this.enemy);
+        this.showAttackResult(this.scale.width - 300, 350, result, `special_${this.player.charType.toLowerCase()}`, true);
+        this.playAttackAnimation(this.playerImage, result.dodged ? null : this.enemyImage, 1);
+
         const effectType = `special_${this.player.charType.toLowerCase()}`;
-        this.effectManager.addAttackEffect(this.scale.width - 300, 350, effectType);
-        
+
         // Track special attack
         const specialAttackData = {
             actionType: 'special_attack',
-            damage: damage,
+            damage: result.damage,
             playerClass: this.player.charType,
             enemyType: this.enemy.enemyType || this.enemy.name,
             enemyHealthRemaining: this.enemy.health,
+            isCritical: result.crit,
             specialType: effectType
         };
-        
+
         if (typeof trackGameEvent !== 'undefined') {
             trackGameEvent('player_special_attack', specialAttackData);
         }
-        
+
         if (typeof Sentry !== 'undefined') {
             Sentry.addBreadcrumb({
-                message: `Player used special attack for ${damage} damage`,
+                message: `Player used special attack for ${result.damage} damage`,
                 category: 'battle_action',
                 level: 'info',
                 data: specialAttackData
             });
         }
-        
+
         this.playerTurn = false;
         this.turnTimer = 60;
-        
+
         this.updateUI();
         this.checkBattleEnd();
+    }
+
+    // Renders damage numbers, misses, and crits for an attack result
+    showAttackResult(x, y, result, effectType, isSpecial = false) {
+        if (result.dodged) {
+            this.effectManager.addDamageNumber(x, y, 'MISS');
+            return;
+        }
+        if (result.crit) {
+            this.effectManager.addDamageNumber(x, y, `${result.damage} CRIT!`, true);
+            this.cameras.main.shake(200, 0.005);
+        } else {
+            this.effectManager.addDamageNumber(x, y, result.damage, isSpecial);
+        }
+        this.effectManager.addAttackEffect(x, y, effectType);
+    }
+
+    playerUsePotion() {
+        if (!this.playerTurn || this.turnTimer > 0 || this.battleOver) return;
+        if (!this.player.hasPotions()) {
+            this.showStatusMessage("No potions in your bag!", 60);
+            return;
+        }
+
+        this.assetManager.playSound(this, 'heal', 0.5);
+
+        const result = this.player.usePotion();
+        this.effectManager.addDamageNumber(300, 350, result.healed, false, true);
+        this.effectManager.addAttackEffect(300, 350, 'spell_heal');
+        this.showStatusMessage(`${result.name}: restored ${result.healed} HP!`, 120);
+
+        if (typeof trackGameEvent !== 'undefined') {
+            trackGameEvent('potion_used', {
+                potionName: result.name,
+                healAmount: result.healed,
+                playerClass: this.player.charType,
+                potionsRemaining: this.player.potions.length
+            });
+        }
+
+        this.playerTurn = false;
+        this.turnTimer = 60;
+
+        this.updateUI();
     }
     
     playerHeal() {
@@ -636,10 +725,16 @@ class BattleScene extends Phaser.Scene {
     enemyTurn() {
         if (this.battleOver || this.enemy.health <= 0) return;
         
+        // Wizards slowly recover mana every round
+        this.player.regenerateMana(GAME_CONSTANTS.MANA.REGEN_PER_TURN);
+
         // Check if enemy is frozen
         if (this.enemy.frozenTurns > 0) {
             this.enemy.frozenTurns--;
-            this.showStatusMessage(`Enemy frozen! ${this.enemy.frozenTurns} turns remaining`, 120);
+            const remaining = this.enemy.frozenTurns;
+            this.showStatusMessage(remaining > 0 ?
+                `Enemy is frozen solid! (${remaining} more turn${remaining === 1 ? '' : 's'})` :
+                'Enemy is frozen solid!', 120);
             
             // Track enemy frozen turn
             if (typeof Sentry !== 'undefined') {
@@ -656,32 +751,37 @@ class BattleScene extends Phaser.Scene {
             
             this.playerTurn = true;
             this.turnTimer = 60;
+            this.updateUI();
             return;
         }
-        
-        // Simple AI
+
+        // Enemy AI: only heals when actually hurt, otherwise attacks
+        const canHeal = this.enemy.health < this.enemy.maxHealth * 0.6;
         const action = Math.random();
         let actionType, damage;
-        
-        if (action < 0.6) {
-            // Attack
-            actionType = 'attack';
-            damage = this.enemy.attackEnemy(this.player);
-            this.effectManager.addDamageNumber(300, 350, damage);
-            this.effectManager.addAttackEffect(300, 350, 'slash');
-        } else if (action < 0.8) {
-            // Special attack
-            actionType = 'special_attack';
-            damage = this.enemy.specialAttack(this.player);
-            this.effectManager.addDamageNumber(300, 350, damage, true);
-            this.effectManager.addAttackEffect(300, 350, `special_${this.enemy.enemyType}`);
-        } else {
+
+        if (canHeal && action < 0.2) {
             // Heal
             actionType = 'heal';
             damage = this.enemy.heal();
             this.effectManager.addDamageNumber(this.scale.width - 300, 350, damage, false, true);
+            this.effectManager.addAttackEffect(this.scale.width - 300, 350, 'spell_heal');
+        } else if (action < 0.75) {
+            // Attack
+            actionType = 'attack';
+            const result = this.enemy.attackEnemy(this.player);
+            damage = result.damage;
+            this.showAttackResult(300, 350, result, 'slash');
+            this.playAttackAnimation(this.enemyImage, result.dodged ? null : this.playerImage, -1);
+        } else {
+            // Special attack
+            actionType = 'special_attack';
+            const result = this.enemy.specialAttack(this.player);
+            damage = result.damage;
+            this.showAttackResult(300, 350, result, `special_${this.enemy.enemyType}`, true);
+            this.playAttackAnimation(this.enemyImage, result.dodged ? null : this.playerImage, -1);
         }
-        
+
         // Track enemy action
         const enemyActionData = {
             actionType: actionType,
@@ -746,11 +846,18 @@ class BattleScene extends Phaser.Scene {
         
         // Update turn indicator
         this.turnIndicator.setText(this.playerTurn ? "Your Turn" : "Enemy Turn");
-        
-        // Update battle buttons for wizards
-        if (this.player.charType === CharacterType.WIZARD) {
-            this.createBattleButtons();
-        }
+        this.turnIndicator.setStyle({ fill: this.playerTurn ? '#7CFC7C' : '#FF8888' });
+
+        // Rebuild action buttons (updates potion count and spell affordability),
+        // then dim them while it's not the player's turn
+        this.createBattleButtons();
+        const buttonAlpha = this.playerTurn && !this.battleOver ? 1.0 : 0.5;
+        this.battleButtons.forEach(btn => {
+            const alpha = btn.alwaysOn ? 1.0 : buttonAlpha;
+            if (btn.rect) btn.rect.setAlpha(alpha);
+            if (btn.text) btn.text.setAlpha(alpha);
+            if (btn.label) btn.label.setAlpha(alpha);
+        });
     }
     
     showStatusMessage(message, duration) {
@@ -767,7 +874,7 @@ class BattleScene extends Phaser.Scene {
             const defeatData = {
                 battleResult: 'defeat',
                 playerClass: this.player.charType,
-                playerLevel: this.player.level,
+                playerLevel: this.player.victories + 1,
                 locationName: this.location.name,
                 enemyType: this.enemy.enemyType || this.enemy.name,
                 enemyHealthRemaining: this.enemy.health,
@@ -796,7 +903,7 @@ class BattleScene extends Phaser.Scene {
             const victoryData = {
                 battleResult: 'victory',
                 playerClass: this.player.charType,
-                playerLevel: this.player.level,
+                playerLevel: this.player.victories + 1,
                 locationName: this.location.name,
                 enemyType: this.enemy.enemyType || this.enemy.name,
                 playerHealthRemaining: this.player.health,
@@ -828,36 +935,34 @@ class BattleScene extends Phaser.Scene {
         this.assetManager.playSound(this, 'victory', 0.8);
         
         // Calculate rewards (improved gold economy)
-        const goldReward = Math.floor(Math.random() * 31) + 30 + this.location.minVictoriesRequired * 15; // Increased base and multiplier
+        const goldReward = Math.floor(Math.random() * 31) + 40 + this.location.minVictoriesRequired * 25;
         const shardReward = Math.floor(Math.random() * 3) + 1;
-        
-        // Check for level up
-        const oldLevel = this.player.level;
-        
+
         // Update player
         this.player.victories++;
         this.player.gold += goldReward;
         this.player.dragonShards += shardReward;
         this.player.locationVictories[this.location.name] = (this.player.locationVictories[this.location.name] || 0) + 1;
-        
-        // Check for level up after victory
-        const newLevel = this.player.level;
-        const leveledUp = newLevel > oldLevel;
-        
+
+        // Every victory grants permanent stat gains (the level-up system)
+        const gains = this.player.applyVictoryGains();
+
         // Check for final victory at Battle of Druids Castle
-        const isFinaleVictory = this.location.name === "Battle of Druids Castle" && 
+        const isFinaleVictory = this.location.name === "Battle of Druids Castle" &&
                                this.player.locationVictories[this.location.name] === 3;
-        
-        console.log(`🏰 Victory check: Location=${this.location.name}, Victories=${this.player.locationVictories[this.location.name]}, IsFinale=${isFinaleVictory}`);
-        
+
+        // Save progress
+        if (typeof SaveSystem !== 'undefined') {
+            SaveSystem.save(this.player);
+        }
+
         // Track victory rewards and level up
         const rewardsData = {
             goldReward: goldReward,
             shardReward: shardReward,
             totalVictories: this.player.victories,
             locationVictories: this.player.locationVictories[this.location.name],
-            playerLevel: newLevel,
-            leveledUp: leveledUp,
+            playerLevel: this.player.victories + 1,
             isFinaleVictory: isFinaleVictory,
             totalGold: this.player.gold,
             totalShards: this.player.dragonShards
@@ -869,43 +974,19 @@ class BattleScene extends Phaser.Scene {
         
         if (typeof Sentry !== 'undefined') {
             Sentry.addBreadcrumb({
-                message: `Victory rewards: ${goldReward} gold, ${shardReward} shards${leveledUp ? ', LEVEL UP!' : ''}`,
+                message: `Victory rewards: ${goldReward} gold, ${shardReward} shards, level up!`,
                 category: 'battle_result',
                 level: 'info',
                 data: rewardsData
             });
         }
-        
-        // Track level up if it occurred
-        if (leveledUp) {
-            const levelUpData = {
-                oldLevel: oldLevel,
-                newLevel: newLevel,
-                playerClass: this.player.charType,
-                totalVictories: this.player.victories,
-                locationName: this.location.name
-            };
-            
-            if (typeof trackGameEvent !== 'undefined') {
-                trackGameEvent('level_up', levelUpData);
-            }
-            
-            if (typeof Sentry !== 'undefined') {
-                Sentry.addBreadcrumb({
-                    message: `Level up! ${oldLevel} -> ${newLevel}`,
-                    category: 'progression',
-                    level: 'info',
-                    data: levelUpData
-                });
-            }
-        }
-        
+
         // Track finale victory
         if (isFinaleVictory) {
             if (typeof trackGameEvent !== 'undefined') {
                 trackGameEvent('finale_victory', {
                     playerClass: this.player.charType,
-                    playerLevel: this.player.level,
+                    playerLevel: this.player.victories + 1,
                     totalVictories: this.player.victories,
                     completionTime: Date.now() - (this.battleStartTime || Date.now())
                 });
@@ -918,7 +999,7 @@ class BattleScene extends Phaser.Scene {
                     level: 'info',
                     data: {
                         playerClass: this.player.charType,
-                        playerLevel: this.player.level,
+                        playerLevel: this.player.victories + 1,
                         totalVictories: this.player.victories
                     }
                 });
@@ -929,50 +1010,71 @@ class BattleScene extends Phaser.Scene {
         if (isFinaleVictory) {
             this.showFinaleVictory();
         } else {
-            this.showRegularVictory(goldReward, shardReward);
+            this.showRegularVictory(goldReward, shardReward, gains);
         }
     }
-    
-    showRegularVictory(goldReward, shardReward) {
+
+    showRegularVictory(goldReward, shardReward, gains) {
         const { width, height } = this.scale;
-        
-        // Victory overlay
-        const overlay = this.add.rectangle(width / 2, height / 2, width, height, COLORS.BLACK, 0.8);
-        
-        this.add.text(width / 2, height / 2 - 100, 'VICTORY!', {
+
+        // Victory overlay (interactive so battle buttons underneath can't be clicked)
+        const overlay = this.add.rectangle(width / 2, height / 2, width, height, COLORS.BLACK, 0.8)
+            .setInteractive();
+
+        const victoryTitle = this.add.text(width / 2, height / 2 - 130, 'VICTORY!', {
             fontSize: '64px',
             fontFamily: 'Arial',
             fill: '#FFD700',
             stroke: '#000000',
             strokeThickness: 3
         }).setOrigin(0.5);
-        
+
+        // Little celebratory pop
+        victoryTitle.setScale(0.3);
+        this.tweens.add({
+            targets: victoryTitle,
+            scaleX: 1,
+            scaleY: 1,
+            duration: 400,
+            ease: 'Back.easeOut'
+        });
+
         const rewardText = [
             `Gold Earned: +${goldReward}`,
             `Dragon Shards: +${shardReward}`,
             `Total Victories: ${this.player.victories}`,
-            `Location Cleared: ${this.location.name}`
+            `Location: ${this.location.name} (${this.player.locationVictories[this.location.name]}/3)`
         ];
-        
+
         rewardText.forEach((text, index) => {
-            this.add.text(width / 2, height / 2 - 20 + index * 30, text, {
+            this.add.text(width / 2, height / 2 - 50 + index * 30, text, {
                 fontSize: '20px',
                 fontFamily: 'Arial',
                 fill: '#FFFFFF'
             }).setOrigin(0.5);
         });
-        
+
+        // Level-up banner
+        this.add.text(width / 2, height / 2 + 90,
+            `⬆ Level ${this.player.victories + 1}!  +${gains.HEALTH_PER_VICTORY} Max HP, +${gains.ATTACK_PER_VICTORY} Attack, +${gains.DEFENSE_PER_VICTORY} Defense`, {
+            fontSize: '22px',
+            fontFamily: 'Arial',
+            fill: '#7CFC7C',
+            stroke: '#000000',
+            strokeThickness: 2
+        }).setOrigin(0.5);
+
         // Continue button
-        const continueBtn = this.add.rectangle(width / 2, height / 2 + 150, 200, 50, COLORS.GREEN)
+        const continueBtn = this.add.rectangle(width / 2, height / 2 + 160, 200, 50, COLORS.GREEN)
             .setStrokeStyle(2, COLORS.WHITE)
             .setInteractive();
-        
-        this.add.text(width / 2, height / 2 + 150, 'Continue', {
+
+        this.add.text(width / 2, height / 2 + 160, 'Continue', {
             fontSize: '20px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
         }).setOrigin(0.5);
-        
+
         continueBtn.on('pointerdown', () => {
             this.registry.set('currentPlayer', this.player);
             this.scene.start('WorldMap'); // Return to world map instead of main menu
@@ -984,9 +1086,10 @@ class BattleScene extends Phaser.Scene {
         
         // Play victory fanfare
         this.assetManager.playVictoryFanfare(this, 0.8);
-        
-        // Dark overlay background
-        const overlay = this.add.rectangle(width / 2, height / 2, width, height, COLORS.BLACK, 0.9);
+
+        // Dark overlay background (interactive to block battle buttons underneath)
+        const overlay = this.add.rectangle(width / 2, height / 2, width, height, COLORS.BLACK, 0.9)
+            .setInteractive();
         
         // Show victory image if loaded, otherwise use colored background
         let victoryImage = null;
@@ -1096,116 +1199,150 @@ class BattleScene extends Phaser.Scene {
     
     showDefeat() {
         const { width, height } = this.scale;
-        
+
         // Play defeat sound
         this.assetManager.playSound(this, 'defeat', 0.7);
-        
-        // Defeat overlay
-        const overlay = this.add.rectangle(width / 2, height / 2, width, height, COLORS.BLACK, 0.8);
-        
-        this.add.text(width / 2, height / 2 - 50, 'DEFEAT', {
+
+        // Defeat overlay (interactive to block battle buttons underneath)
+        const elements = [];
+        const overlay = this.add.rectangle(width / 2, height / 2, width, height, COLORS.BLACK, 0.8)
+            .setInteractive();
+        elements.push(overlay);
+
+        elements.push(this.add.text(width / 2, height / 2 - 80, 'DEFEAT', {
             fontSize: '64px',
             fontFamily: 'Arial',
             fill: '#FF0000',
             stroke: '#000000',
             strokeThickness: 3
-        }).setOrigin(0.5);
-        
-        this.add.text(width / 2, height / 2 + 20, 'Better luck next time, warrior!', {
+        }).setOrigin(0.5));
+
+        elements.push(this.add.text(width / 2, height / 2 - 10, 'Better luck next time, warrior!', {
             fontSize: '24px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
-        }).setOrigin(0.5);
-        
+        }).setOrigin(0.5));
+
+        // Dragon Shard revive option - get back up and keep fighting!
+        const reviveCost = GAME_CONSTANTS.REVIVE_SHARD_COST;
+        if (this.player.dragonShards >= reviveCost) {
+            const reviveBtn = this.add.rectangle(width / 2, height / 2 + 60, 320, 50, 0x6a0dad)
+                .setStrokeStyle(2, COLORS.GOLD)
+                .setInteractive();
+            const reviveText = this.add.text(width / 2, height / 2 + 60,
+                `Revive! (${reviveCost} Dragon Shards)`, {
+                fontSize: '20px',
+                fontFamily: 'Arial',
+                fill: '#FFD700'
+            }).setOrigin(0.5);
+            elements.push(reviveBtn, reviveText);
+
+            reviveBtn.on('pointerover', () => reviveBtn.setFillStyle(0x8a2dcd));
+            reviveBtn.on('pointerout', () => reviveBtn.setFillStyle(0x6a0dad));
+            reviveBtn.on('pointerdown', () => {
+                this.player.dragonShards -= reviveCost;
+                this.player.health = Math.floor(this.player.maxHealth * 0.5);
+                this.battleOver = false;
+                this.playerTurn = true;
+                this.turnTimer = 30;
+
+                elements.forEach(el => el.destroy());
+                this.assetManager.playSound(this, 'heal', 0.6);
+                this.effectManager.addDamageNumber(300, 350, this.player.health, false, true);
+                this.showStatusMessage('The Dragon Shards revive you!', 120);
+                this.updateUI();
+
+                if (typeof trackGameEvent !== 'undefined') {
+                    trackGameEvent('shard_revive', {
+                        shardsRemaining: this.player.dragonShards,
+                        locationName: this.location.name
+                    });
+                }
+            });
+        }
+
         // Continue button
-        const continueBtn = this.add.rectangle(width / 2, height / 2 + 100, 200, 50, COLORS.RED)
+        const continueBtn = this.add.rectangle(width / 2, height / 2 + 130, 200, 50, COLORS.RED)
             .setStrokeStyle(2, COLORS.WHITE)
             .setInteractive();
-        
-        this.add.text(width / 2, height / 2 + 100, 'Continue', {
+        elements.push(continueBtn);
+
+        elements.push(this.add.text(width / 2, height / 2 + 130, 'Continue', {
             fontSize: '20px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
-        }).setOrigin(0.5);
-        
+        }).setOrigin(0.5));
+
         continueBtn.on('pointerdown', () => {
             // Restore player health
             this.player.health = this.player.maxHealth;
             this.registry.set('currentPlayer', this.player);
+            if (typeof SaveSystem !== 'undefined') {
+                SaveSystem.save(this.player);
+            }
             this.scene.start('MainMenu');
         });
     }
     
     forfeitBattle() {
-        // Track battle forfeit
-        const forfeitData = {
-            battleResult: 'forfeit',
-            playerClass: this.player.charType,
-            playerLevel: this.player.level,
-            locationName: this.location.name,
-            enemyType: this.enemy.enemyType || this.enemy.name,
-            playerHealthRemaining: this.player.health,
-            enemyHealthRemaining: this.enemy.health,
-            battleDuration: Date.now() - (this.battleStartTime || Date.now())
-        };
-        
-        if (typeof trackGameEvent !== 'undefined') {
-            trackGameEvent('battle_forfeit', forfeitData);
-        }
-        
-        if (typeof Sentry !== 'undefined') {
-            Sentry.addBreadcrumb({
-                message: 'Battle forfeited by player',
-                category: 'battle_result',
-                level: 'info',
-                data: forfeitData
-            });
-        }
-        
         // Show confirmation dialog
         const { width, height } = this.scale;
-        
+        const elements = [];
+
         const overlay = this.add.rectangle(width / 2, height / 2, width, height, COLORS.BLACK, 0.8)
             .setInteractive();
-        
-        const dialogBg = this.add.rectangle(width / 2, height / 2, 300, 200, COLORS.DARK_GRAY)
-            .setStrokeStyle(3, COLORS.WHITE);
-        
-        this.add.text(width / 2, height / 2 - 40, 'Forfeit Battle?', {
+        elements.push(overlay);
+
+        elements.push(this.add.rectangle(width / 2, height / 2, 320, 200, COLORS.DARK_GRAY)
+            .setStrokeStyle(3, COLORS.WHITE));
+
+        elements.push(this.add.text(width / 2, height / 2 - 40, 'Flee from battle?', {
             fontSize: '24px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
-        }).setOrigin(0.5);
-        
+        }).setOrigin(0.5));
+
         // Yes button
         const yesBtn = this.add.rectangle(width / 2 - 60, height / 2 + 30, 100, 40, COLORS.RED)
             .setStrokeStyle(2, COLORS.WHITE)
             .setInteractive();
-        
-        this.add.text(width / 2 - 60, height / 2 + 30, 'Yes', {
+        elements.push(yesBtn);
+
+        elements.push(this.add.text(width / 2 - 60, height / 2 + 30, 'Yes', {
             fontSize: '18px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
-        }).setOrigin(0.5);
-        
+        }).setOrigin(0.5));
+
         yesBtn.on('pointerdown', () => {
+            if (typeof trackGameEvent !== 'undefined') {
+                trackGameEvent('battle_forfeit', {
+                    battleResult: 'forfeit',
+                    playerClass: this.player.charType,
+                    locationName: this.location.name,
+                    enemyType: this.enemy.enemyType || this.enemy.name,
+                    playerHealthRemaining: this.player.health,
+                    enemyHealthRemaining: this.enemy.health,
+                    battleDuration: Date.now() - (this.battleStartTime || Date.now())
+                });
+            }
             this.scene.start('MainMenu');
         });
-        
+
         // No button
         const noBtn = this.add.rectangle(width / 2 + 60, height / 2 + 30, 100, 40, COLORS.GREEN)
             .setStrokeStyle(2, COLORS.WHITE)
             .setInteractive();
-        
-        this.add.text(width / 2 + 60, height / 2 + 30, 'No', {
+        elements.push(noBtn);
+
+        elements.push(this.add.text(width / 2 + 60, height / 2 + 30, 'No', {
             fontSize: '18px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
-        }).setOrigin(0.5);
-        
+        }).setOrigin(0.5));
+
         noBtn.on('pointerdown', () => {
-            overlay.destroy();
-            dialogBg.destroy();
+            elements.forEach(el => el.destroy());
         });
     }
     
@@ -1234,26 +1371,17 @@ class BattleScene extends Phaser.Scene {
     }
     
     showEnemyDialogue(enemyType) {
-        console.log(`💬 showEnemyDialogue called with enemyType: ${enemyType}`);
-        console.log(`💬 Enemy object:`, this.enemy);
-        console.log(`💬 Enemy name: ${this.enemy?.name}, Enemy type: ${this.enemy?.enemyType}`);
         const { width, height } = this.scale;
-        
+
         // Get random dialogue for this enemy type
         let dialogue = "Let's battle!"; // Default fallback
         if (ENEMY_DIALOGUE && ENEMY_DIALOGUE[enemyType]) {
             const dialogues = ENEMY_DIALOGUE[enemyType];
             dialogue = dialogues[Math.floor(Math.random() * dialogues.length)];
-            console.log(`💬 Found dialogue: "${dialogue}"`);
-        } else {
-            console.warn(`💬 No dialogue found for enemy type: ${enemyType}`);
-            console.log(`💬 Available enemy types:`, ENEMY_DIALOGUE ? Object.keys(ENEMY_DIALOGUE) : 'ENEMY_DIALOGUE not loaded');
-            console.log(`💬 Using fallback dialogue: "${dialogue}"`);
         }
-        
+
         // Create dialogue bubble with high depth to appear on top (more visible positioning)
         const dialogueY = 200; // Lower position to avoid conflict with health bars
-        console.log(`💬 Creating dialogue bubble at position (${width / 2}, ${dialogueY})`);
         const dialogueBg = this.add.rectangle(width / 2, dialogueY, width - 60, 120, 0x001133, 0.95)
             .setStrokeStyle(5, COLORS.YELLOW) // Thicker yellow border
             .setDepth(2000); // Even higher depth to appear on top
@@ -1272,7 +1400,6 @@ class BattleScene extends Phaser.Scene {
         
         // Enemy name label
         const enemyName = this.enemy.name || enemyType.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase());
-        console.log(`💬 Enemy name: ${enemyName}`);
         const nameText = this.add.text(width / 2, dialogueY - 45, enemyName + " says:", {
             fontSize: '20px', // Larger font
             fontFamily: 'Arial',
@@ -1282,8 +1409,6 @@ class BattleScene extends Phaser.Scene {
             strokeThickness: 3
         }).setOrigin(0.5)
           .setDepth(2001); // High depth for name text
-        
-        console.log(`💬 Dialogue elements created successfully`);
         
         // Auto-hide after 4 seconds
         this.time.delayedCall(4000, () => {

--- a/battle-of-the-druids/js/scenes/CharacterSelectionScene.js
+++ b/battle-of-the-druids/js/scenes/CharacterSelectionScene.js
@@ -60,6 +60,17 @@ class CharacterSelectionScene extends Phaser.Scene {
         try {
             console.log('🎯 CharacterSelectionScene starting...');
             const { width, height } = this.scale;
+
+            // Reset state - Phaser reuses scene instances, so anything left
+            // over from a previous visit points at destroyed objects
+            this.selectedCharacter = null;
+            this.playerName = "";
+            this.inputActive = false;
+            this.nameInputBox = null;
+            this.nameInputText = null;
+            this.cursor = null;
+            this.startButton = null;
+            this.startButtonText = null;
             
             // Background
             console.log('🎨 Drawing background...');
@@ -93,6 +104,9 @@ class CharacterSelectionScene extends Phaser.Scene {
                 fontFamily: 'Arial',
                 fill: '#FFFFFF'
             }).setOrigin(0.5);
+
+            // Continue button if a saved hero exists
+            this.createContinueButton();
             
             console.log('⌨️ Keyboard input will be enabled when character is selected...');
             // Note: Keyboard listener is registered only when text input is needed
@@ -105,6 +119,40 @@ class CharacterSelectionScene extends Phaser.Scene {
         }
     }
     
+    createContinueButton() {
+        const saveData = (typeof SaveSystem !== 'undefined') ? SaveSystem.peek() : null;
+        if (!saveData) return;
+
+        const { width } = this.scale;
+        const label = `Continue: ${saveData.name} the ${saveData.charType} (Lv ${(saveData.victories || 0) + 1})`;
+
+        const continueBtn = this.add.rectangle(width / 2, 660, 460, 56, 0x1e5c1e)
+            .setStrokeStyle(3, COLORS.GOLD)
+            .setInteractive();
+
+        const continueText = this.add.text(width / 2, 660, label, {
+            fontSize: '22px',
+            fontFamily: 'Arial',
+            fill: '#FFD700',
+            fontStyle: 'bold'
+        }).setOrigin(0.5);
+
+        continueBtn.on('pointerover', () => continueBtn.setFillStyle(0x2e7c2e));
+        continueBtn.on('pointerout', () => continueBtn.setFillStyle(0x1e5c1e));
+        continueBtn.on('pointerdown', () => {
+            const player = SaveSystem.load();
+            if (player) {
+                if (window.trackGameEvent) {
+                    window.trackGameEvent('save_loaded', 'Player_Actions');
+                }
+                this.registry.set('currentPlayer', player);
+                this.scene.start('MainMenu');
+            } else {
+                continueText.setText('Save could not be loaded');
+            }
+        });
+    }
+
     createCharacterCards() {
         try {
             console.log('🃏 Creating character cards...');
@@ -234,6 +282,29 @@ class CharacterSelectionScene extends Phaser.Scene {
         
         // Mobile keyboard support
         this.setupMobileInput();
+
+        // Begin Adventure button (click/tap alternative to pressing Enter)
+        if (!this.startButton) {
+            this.startButton = this.add.rectangle(width / 2, 590, 260, 50, 0x1e5c1e)
+                .setStrokeStyle(2, COLORS.WHITE)
+                .setInteractive();
+            this.startButtonText = this.add.text(width / 2, 590, 'Begin Adventure!', {
+                fontSize: '20px',
+                fontFamily: 'Arial',
+                fill: '#FFFFFF',
+                fontStyle: 'bold'
+            }).setOrigin(0.5);
+
+            this.startButton.on('pointerover', () => this.startButton.setFillStyle(0x2e7c2e));
+            this.startButton.on('pointerout', () => this.startButton.setFillStyle(0x1e5c1e));
+            this.startButton.on('pointerdown', () => {
+                if (this.playerName.trim().length > 0) {
+                    this.createCharacter();
+                } else if (this.instructionText) {
+                    this.instructionText.setText('Please enter a name for your hero first!');
+                }
+            });
+        }
         
         // Blinking cursor
         this.cursor = this.add.text(width / 2 + this.nameInputText.width / 2 + 5, 520, '|', {
@@ -342,9 +413,14 @@ class CharacterSelectionScene extends Phaser.Scene {
         
         // Create character object
         const character = new Character(this.selectedCharacter.type, this.playerName.trim());
-        
+
         // Store globally for other scenes
         this.registry.set('currentPlayer', character);
+
+        // Starting a new hero becomes the active save
+        if (typeof SaveSystem !== 'undefined') {
+            SaveSystem.save(character);
+        }
         
         // Disable keyboard input when character creation is complete
         this.inputActive = false;

--- a/battle-of-the-druids/js/scenes/InventoryScene.js
+++ b/battle-of-the-druids/js/scenes/InventoryScene.js
@@ -45,9 +45,12 @@ class InventoryScene extends Phaser.Scene {
         
         // Create equipment display
         this.createEquipmentDisplay();
-        
+
         // Create stats display
         this.createStatsDisplay();
+
+        // Create potion bag display
+        this.createPotionDisplay();
         
         // Back button
         const backButton = this.add.rectangle(100, height - 80, 120, 40, COLORS.DARK_GRAY)
@@ -93,6 +96,42 @@ class InventoryScene extends Phaser.Scene {
         });
     }
     
+    createPotionDisplay() {
+        const { width } = this.scale;
+        const panelX = width - 175;
+        const panelY = 200;
+        const panelWidth = 250;
+        const panelHeight = 260;
+
+        this.add.rectangle(panelX, panelY + panelHeight / 2, panelWidth, panelHeight, COLORS.BLACK, 0.7)
+            .setStrokeStyle(2, COLORS.WHITE);
+
+        const potions = this.player.potions || [];
+        this.add.text(panelX, panelY + 30, `Potion Bag (${potions.length}/${GAME_CONSTANTS.POTIONS.BAG_LIMIT})`, {
+            fontSize: '20px',
+            fontFamily: 'Arial',
+            fill: '#FFD700',
+            fontStyle: 'bold'
+        }).setOrigin(0.5);
+
+        if (potions.length === 0) {
+            this.add.text(panelX, panelY + 80, 'Empty\nBuy potions at the Store\nto use during battles!', {
+                fontSize: '14px',
+                fontFamily: 'Arial',
+                fill: '#CCCCCC',
+                align: 'center'
+            }).setOrigin(0.5);
+        } else {
+            potions.forEach((potion, index) => {
+                this.add.text(panelX, panelY + 65 + index * 30, `🧪 ${potion.name} (${potion.healPercent}%)`, {
+                    fontSize: '14px',
+                    fontFamily: 'Arial',
+                    fill: '#FFFFFF'
+                }).setOrigin(0.5);
+            });
+        }
+    }
+
     createStatsDisplay() {
         const { width } = this.scale;
         

--- a/battle-of-the-druids/js/scenes/MainMenuScene.js
+++ b/battle-of-the-druids/js/scenes/MainMenuScene.js
@@ -19,7 +19,10 @@ class MainMenuScene extends Phaser.Scene {
     
     create() {
         const { width, height } = this.scale;
-        
+
+        // Reset per-visit state (scene instances are reused)
+        this.buttons = [];
+
         // Get player from registry
         this.player = this.registry.get('currentPlayer');
         
@@ -52,11 +55,17 @@ class MainMenuScene extends Phaser.Scene {
             fill: '#FFFFFF'
         }).setOrigin(0.5);
         
-        this.add.text(width / 2, 250, `Gold: ${this.player.gold} | Dragon Shards: ${this.player.dragonShards}`, {
+        const potionCount = this.player.potions ? this.player.potions.length : 0;
+        this.add.text(width / 2, 250, `Gold: ${this.player.gold} | Dragon Shards: ${this.player.dragonShards} | Potions: ${potionCount}/${GAME_CONSTANTS.POTIONS.BAG_LIMIT}`, {
             fontSize: '20px',
             fontFamily: 'Arial',
             fill: '#FFD700'
         }).setOrigin(0.5);
+
+        // Checkpoint save
+        if (typeof SaveSystem !== 'undefined') {
+            SaveSystem.save(this.player);
+        }
         
         // Create menu buttons
         this.createMenuButtons();
@@ -107,55 +116,61 @@ class MainMenuScene extends Phaser.Scene {
     quitGame() {
         // Create confirmation dialog
         const { width, height } = this.scale;
-        
+        const elements = [];
+
         const overlay = this.add.rectangle(width / 2, height / 2, width, height, COLORS.BLACK, 0.8)
             .setInteractive();
-        
-        const dialogBg = this.add.rectangle(width / 2, height / 2, 300, 200, COLORS.DARK_GRAY)
-            .setStrokeStyle(3, COLORS.WHITE);
-        
-        this.add.text(width / 2, height / 2 - 40, 'Quit Game?', {
+        elements.push(overlay);
+
+        elements.push(this.add.rectangle(width / 2, height / 2, 340, 200, COLORS.DARK_GRAY)
+            .setStrokeStyle(3, COLORS.WHITE));
+
+        elements.push(this.add.text(width / 2, height / 2 - 40, 'Quit Game?', {
             fontSize: '24px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
-        }).setOrigin(0.5);
-        
-        this.add.text(width / 2, height / 2, 'Return to Character Selection?', {
+        }).setOrigin(0.5));
+
+        elements.push(this.add.text(width / 2, height / 2, 'Your progress is saved automatically.', {
             fontSize: '16px',
             fontFamily: 'Arial',
             fill: '#CCCCCC'
-        }).setOrigin(0.5);
-        
+        }).setOrigin(0.5));
+
         // Yes button
         const yesBtn = this.add.rectangle(width / 2 - 60, height / 2 + 50, 100, 40, COLORS.RED)
             .setStrokeStyle(2, COLORS.WHITE)
             .setInteractive();
-        
-        this.add.text(width / 2 - 60, height / 2 + 50, 'Yes', {
+        elements.push(yesBtn);
+
+        elements.push(this.add.text(width / 2 - 60, height / 2 + 50, 'Yes', {
             fontSize: '18px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
-        }).setOrigin(0.5);
-        
+        }).setOrigin(0.5));
+
         yesBtn.on('pointerdown', () => {
+            if (typeof SaveSystem !== 'undefined') {
+                SaveSystem.save(this.player);
+            }
             this.registry.remove('currentPlayer');
             this.scene.start('CharacterSelection');
         });
-        
+
         // No button
         const noBtn = this.add.rectangle(width / 2 + 60, height / 2 + 50, 100, 40, COLORS.GREEN)
             .setStrokeStyle(2, COLORS.WHITE)
             .setInteractive();
-        
-        this.add.text(width / 2 + 60, height / 2 + 50, 'No', {
+        elements.push(noBtn);
+
+        elements.push(this.add.text(width / 2 + 60, height / 2 + 50, 'No', {
             fontSize: '18px',
             fontFamily: 'Arial',
             fill: '#FFFFFF'
-        }).setOrigin(0.5);
-        
+        }).setOrigin(0.5));
+
         noBtn.on('pointerdown', () => {
-            overlay.destroy();
-            dialogBg.destroy();
+            elements.forEach(el => el.destroy());
         });
     }
     

--- a/battle-of-the-druids/js/scenes/StoreScene.js
+++ b/battle-of-the-druids/js/scenes/StoreScene.js
@@ -49,7 +49,7 @@ class StoreScene extends Phaser.Scene {
         }).setOrigin(0.5);
         
         // Player gold display
-        this.goldText = this.add.text(50, 100, `Gold: ${this.player.gold}`, {
+        this.goldText = this.add.text(50, 100, this.getGoldLabel(), {
             fontSize: '24px',
             fontFamily: 'Arial',
             fill: '#FFD700'
@@ -89,6 +89,11 @@ class StoreScene extends Phaser.Scene {
         // Note: Keyboard input disabled to prevent mobile keyboard popup
     }
     
+    getGoldLabel() {
+        const potionCount = this.player.potions ? this.player.potions.length : 0;
+        return `Gold: ${this.player.gold}   Potions: ${potionCount}/${GAME_CONSTANTS.POTIONS.BAG_LIMIT}`;
+    }
+
     createTierButtons() {
         const { width } = this.scale;
         const tiers = Object.values(ItemTier);
@@ -182,10 +187,12 @@ class StoreScene extends Phaser.Scene {
         // Determine if this is equipment or consumable
         const isEquipment = item.slot !== undefined;
         const canAfford = this.player.gold >= item.price;
-        
+        const equippedItem = isEquipment ? this.player.getEquippedItem(item.slot) : null;
+        const isEquipped = !!(equippedItem && equippedItem.name === item.name);
+
         // Item card background
         const cardBg = this.add.rectangle(width / 2, y, cardWidth, cardHeight, canAfford ? COLORS.DARK_GRAY : 0x3c1414)
-            .setStrokeStyle(2, COLORS.WHITE)
+            .setStrokeStyle(2, isEquipped ? COLORS.GOLD : COLORS.WHITE)
             .setInteractive();
         
         // Item name
@@ -208,27 +215,41 @@ class StoreScene extends Phaser.Scene {
         if (isEquipment) {
             const equipment = new Equipment(item);
             statsText = equipment.getStatText();
-        } else {
-            if (item.health) statsText += `Health +${item.health} `;
+        } else if (item.healPercent) {
+            statsText = `Restores ${item.healPercent}% HP in battle`;
         }
-        
+
+        // Track every element so tier switches clean them up properly
+        let statsTextObj = null;
         if (statsText) {
-            this.add.text(400, y, statsText, {
+            statsTextObj = this.add.text(400, y, statsText, {
                 fontSize: '16px',
                 fontFamily: 'Arial',
                 fill: '#00FF00'
             });
         }
-        
+
         // Tier indicator for equipment
+        let tierCircle = null;
         if (isEquipment) {
             const tierColor = TIER_COLORS[item.tier];
-            this.add.circle(width - 100, y, 15, tierColor)
+            tierCircle = this.add.circle(width - 100, y, 15, tierColor)
                 .setStrokeStyle(2, COLORS.WHITE);
         }
-        
+
+        // Equipped indicator
+        let equippedText = null;
+        if (isEquipped) {
+            equippedText = this.add.text(width - 180, y, 'EQUIPPED', {
+                fontSize: '16px',
+                fontFamily: 'Arial',
+                fill: '#FFD700',
+                fontStyle: 'bold'
+            }).setOrigin(0.5);
+        }
+
         // Purchase interaction
-        if (canAfford) {
+        if (canAfford && !isEquipped) {
             cardBg.on('pointerdown', () => this.purchaseItem(item));
             cardBg.on('pointerover', () => cardBg.setFillStyle(COLORS.GRAY));
             cardBg.on('pointerout', () => cardBg.setFillStyle(COLORS.DARK_GRAY));
@@ -239,7 +260,9 @@ class StoreScene extends Phaser.Scene {
             cardBg,
             nameText,
             priceText,
-            item
+            statsTextObj,
+            tierCircle,
+            equippedText
         });
     }
     
@@ -249,16 +272,21 @@ class StoreScene extends Phaser.Scene {
         if (result.success) {
             // Play purchase sound
             this.assetManager.playSound(this, 'buy', 0.6);
-            
+
             // Update gold display
-            this.goldText.setText(`Gold: ${this.player.gold}`);
-            
+            this.goldText.setText(this.getGoldLabel());
+
             // Show success message
             this.showPurchaseMessage(result.message, true);
-            
+
             // Refresh item display to update affordability
             this.updateItemDisplay();
-            
+
+            // Save after every purchase
+            if (typeof SaveSystem !== 'undefined') {
+                SaveSystem.save(this.player);
+            }
+
         } else {
             // Show failure message
             this.showPurchaseMessage(result.message, false);

--- a/battle-of-the-druids/js/scenes/WorldMapScene.js
+++ b/battle-of-the-druids/js/scenes/WorldMapScene.js
@@ -20,7 +20,10 @@ class WorldMapScene extends Phaser.Scene {
     
     create() {
         const { width, height } = this.scale;
-        
+
+        // Reset per-visit state (scene instances are reused)
+        this.locationCircles = [];
+
         // Get player from registry
         this.player = this.registry.get('currentPlayer');
         
@@ -51,6 +54,22 @@ class WorldMapScene extends Phaser.Scene {
             fontFamily: 'Arial',
             fill: '#FFFFFF'
         }).setOrigin(0.5);
+
+        // Player status header
+        const potionCount = this.player.potions ? this.player.potions.length : 0;
+        this.add.text(width / 2, 135,
+            `${this.player.name}  •  Lv ${this.player.victories + 1}  •  Gold: ${this.player.gold}  •  Shards: ${this.player.dragonShards}  •  Potions: ${potionCount}`, {
+            fontSize: '18px',
+            fontFamily: 'Arial',
+            fill: '#FFD700',
+            stroke: '#000000',
+            strokeThickness: 2
+        }).setOrigin(0.5);
+
+        // Checkpoint save whenever the map is visited
+        if (typeof SaveSystem !== 'undefined') {
+            SaveSystem.save(this.player);
+        }
         
         // Main Menu button (bottom-right corner)
         const mainMenuBtn = this.add.rectangle(width - 100, height - 50, 160, 40, COLORS.DARK_GRAY)
@@ -145,33 +164,38 @@ class WorldMapScene extends Phaser.Scene {
             }
             
             // Interaction handlers
-            if (isUnlocked && victories < 3) {
+            if (isUnlocked) {
+                // Completed locations stay open for replay (gold and shard grinding)
                 locationCircle.on('pointerdown', () => {
                     this.selectLocation(location);
                 });
-                
+
                 locationCircle.on('pointerover', () => {
                     locationCircle.setScale(1.1);
-                    this.showLocationDescription(location);
+                    if (victories >= 3) {
+                        this.showCompletedMessage(location);
+                    } else {
+                        this.showLocationDescription(location);
+                    }
                 });
-                
+
                 locationCircle.on('pointerout', () => {
                     locationCircle.setScale(1.0);
                     this.hideLocationDescription();
                 });
-            } else if (isUnlocked && victories >= 3) {
-                // Completed location - show info but can't enter
-                locationCircle.on('pointerover', () => {
-                    this.showCompletedMessage(location);
-                });
-                
-                locationCircle.on('pointerout', () => {
-                    this.hideLocationDescription();
-                });
-                
-                locationCircle.on('pointerdown', () => {
-                    this.showCompletedMessage(location);
-                });
+
+                // Pulse locations that still have progress to earn
+                if (victories < 3) {
+                    this.tweens.add({
+                        targets: locationCircle,
+                        scaleX: 1.12,
+                        scaleY: 1.12,
+                        duration: 900,
+                        yoyo: true,
+                        repeat: -1,
+                        ease: 'Sine.easeInOut'
+                    });
+                }
             } else {
                 // Show locked state
                 locationCircle.on('pointerover', () => {
@@ -244,7 +268,7 @@ class WorldMapScene extends Phaser.Scene {
     }
     
     showCompletedMessage(location) {
-        this.hoverDescription.setText(`${location.name} - COMPLETED!\nYou've defeated all enemies here. (3/3)\nTry exploring other locations!`);
+        this.hoverDescription.setText(`${location.name} - COMPLETED! (3/3)\nYou can still battle here for extra gold and shards.`);
         this.hoverDescription.setVisible(true);
     }
     


### PR DESCRIPTION
# Battle of the Druids — Comprehensive Review & Overhaul

A full review of the web game turned up serious balance problems, several memory leaks, dead code, and missing quality-of-life features. This PR fixes all of them and adds the polish features the game was clearly missing.

## 🐛 Bug fixes

- **Wizard button leak** — battle buttons were rebuilt after every action but the mana-cost labels were never destroyed, stacking text objects forever
- **Store leak** — stat texts and tier circles weren't tracked, so they piled up when switching item tiers
- **Dialog leaks** — the quit and forfeit dialogs destroyed only the overlay on "No", leaving their buttons and labels alive and clickable
- **Music restarts** — background music restarted from zero on every scene change; BattleScene also tried to stop an audio key that doesn't exist
- **Ad-blocker crash** — `Sentry.init` ran unguarded, throwing on load whenever the Sentry CDN is blocked
- **Stale scene state** — Phaser reuses scene instances; character selection kept the old name/selection on revisit
- **Broken analytics** — events referenced undefined `player.level` / `player.attack`
- **Dark Mage art** — rendered a 72px placeholder; now uses the full-res `elite_dark_mage` art (Phaser silently ignores a second `load.image` with a duplicate key, so the placeholder had to be dequeued)

## ⚖️ Balance — verified by simulation

Simulated full playthroughs (using the real game code) showed the endgame was **mathematically unbeatable** without exploiting the old potion bug that permanently stacked max HP. After rebalancing, **all four classes complete the game (78/80 simulated runs)** with a real difficulty curve — occasional defeats mid-game, hardest at the optional Bot Attack zone.

- **Level-ups**: +5 max HP / +2 ATK / +2 DEF per victory, shown on the victory screen
- **Enemy scaling**: victory scaling capped at +30%, enemy attack grows at half the rate of health/defense, boss areas trimmed, enemy speed unscaled
- **Speed matters now**: it drives crit chance (Rogue +10%, finally matching its description) and dodge chance
- **Healing scales with max HP** (25–35%; Wizard spell 35–50%) instead of a flat 25–40 that was useless late game
- **Spells fixed**: Fireball/Ice Shard used flat defense subtraction and did ~1 damage to armored enemies; they now use the same proportional formula as attacks and scale with victories; wizards regen 5 mana per round passively
- **Smarter enemy AI**: heals only when actually hurt (was wasting turns healing at full HP), with weaker self-heals (10–15%)

## ✨ New features

- **Save system** (localStorage) — auto-saves after battles, purchases, and menu visits; "Continue: \<hero\> (Lv N)" button on the character screen
- **Potion bag** — potions are now consumables carried into battle (bag of 5) with a "Potion (n)" combat button, replacing the exploit-prone permanent max-HP boosts
- **Dragon Shard revive** — shards finally have a purpose: spend 3 on defeat to revive at 50% HP and keep fighting
- **Flee button** — the forfeit flow existed but was unreachable dead code
- **"Begin Adventure" button** — character creation no longer requires the Enter key (mobile-friendly)
- **Replayable locations** — completed areas stay open for gold/shard grinding (previously the economy dead-ended at 27 total battles)

## 🎨 Polish

Attack lunge animations, hit flashes, idle bobbing, crit screen-shake, "MISS" indicators, victory banner pop-in, colored turn indicator, dimmed buttons during the enemy turn, world-map status header (level/gold/shards/potions), pulsing markers on locations with progress remaining, EQUIPPED labels in the store, and removal of per-frame console spam.

## ✅ Verification

- `node --check` passes on all files
- Simulated playthroughs of all 4 classes confirm the game is beatable with a fair curve
- **Full E2E in headless Chromium (Playwright)**: boot → create Knight → buy potion → battle → attack/flee-cancel/potion-use → victory with level-up → reload page → continue from save; plus Wizard spell casting (mana economy + no object leaks over 10 combat rounds) and the defeat → shard-revive → keep-fighting path. Zero console/page errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0119ZmPdRsAhGYYjssjMe257

---
_Generated by [Claude Code](https://claude.ai/code/session_0119ZmPdRsAhGYYjssjMe257)_