### PR TITLE
Add a story layer: prologues, wave beats, and epilogues

### DIFF
--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -85,6 +85,12 @@ body { background:#000; overflow:hidden; font-family:'Segoe UI',Arial,sans-serif
 #event-timer-bar-wrap { width:260px; height:8px; background:rgba(0,0,0,0.5); border-radius:4px; margin:10px auto 0; overflow:hidden; }
 #event-timer-bar { height:100%; background:linear-gradient(90deg,#ff8800,#FFD700); border-radius:4px; transition:width 0.5s linear; box-shadow:0 0 6px rgba(255,215,0,0.5); }
 
+/* Story beat banner */
+#story-beat { position:absolute; top:38%; left:50%; transform:translate(-50%,-50%) scale(0.96); max-width:560px; width:88%; color:#f3e9d0; text-align:center; background:linear-gradient(160deg,rgba(30,20,10,0.94),rgba(15,10,6,0.94)); border:2px solid rgba(230,190,120,0.55); border-radius:16px; padding:20px 28px; pointer-events:none; opacity:0; transition:opacity 0.5s, transform 0.5s; box-shadow:0 0 40px rgba(220,170,90,0.18), inset 0 1px 0 rgba(255,240,210,0.08); backdrop-filter:blur(5px); z-index:8; }
+#story-beat.show { opacity:1; transform:translate(-50%,-50%) scale(1); }
+#story-beat .sb-title { font-size:20px; font-weight:bold; color:#f5c977; letter-spacing:0.5px; margin-bottom:8px; text-shadow:0 0 14px rgba(245,201,119,0.35); }
+#story-beat .sb-text { font-size:15px; line-height:1.65; font-style:italic; color:#e7dcc4; }
+
 /* Controls hint */
 #hint { position:absolute; bottom:100px; right:12px; background:rgba(0,0,0,0.65); border-radius:10px; padding:10px 14px; color:rgba(255,255,255,0.5); font-size:11px; line-height:2.0; border:1px solid rgba(255,255,255,0.08); backdrop-filter:blur(4px); }
 
@@ -166,6 +172,7 @@ body { background:#000; overflow:hidden; font-family:'Segoe UI',Arial,sans-serif
 </div>
 <div id="wave-start-btn">▶ START WAVE</div>
 <div id="event-banner"><span id="event-text"></span><div id="event-timer-bar-wrap"><div id="event-timer-bar"></div></div></div>
+<div id="story-beat"><div class="sb-title" id="story-beat-title"></div><div class="sb-text" id="story-beat-text"></div></div>
 
   <!-- Shop -->
   <div id="shop-overlay">
@@ -1639,7 +1646,11 @@ function exitArea() {
 }
 
 // Button hooks
-function enterCavern() { enterArea(AREA_CAVERN); }
+function enterCavern() {
+  enterArea(AREA_CAVERN);
+  setTimeout(() => showStoryBeat('📜 The Molten Cavern',
+    'Beneath the farm, a crack in the earth breathes heat. Down here the old fire-things hoard weapons forged before your family ever planted a seed. Take what you can carry — and don\'t linger in the dark.'), 900);
+}
 function exitForest()  { exitArea(); }
 
 const ENEMY_TYPES = [
@@ -4138,6 +4149,7 @@ function startNextWave() {
   const label = waveLabels[gs.wave] || '⚠️ WAVE ' + gs.wave + '!';
   showWaveAnn(label);
   showToast('Wave ' + gs.wave + ' / ' + totalWaves + ' incoming!', 2200);
+  triggerWaveStory(gs.wave);
 }
 
 function checkWaveEnd() {
@@ -6010,10 +6022,114 @@ function expandFarm() {
 // ═══════════════════════════════════════
 //  SCREENS
 // ═══════════════════════════════════════
+// ═══════════════════════════════════════
+//  STORY & LORE
+// ═══════════════════════════════════════
+const BIOME_STORY = {
+  garden: {
+    title: '🌾 The Garden Farm',
+    intro: [
+      'For three generations your family has tended this quiet patch of soil.',
+      'But the harvest moon has risen blood-red, and the old scarecrows have torn themselves from their posts — an endless army marching from the ruined fortress to the north.',
+      'You are the last farmer standing. Grab your carrot spear. The barn must not fall.',
+    ],
+    beats: {
+      5:  ['The First Warlord', 'A hulking BOSS Scarecrow drags itself over the fence, straw smoking. The little ones scatter behind it — this is no random mob. Someone is <b>commanding</b> them.'],
+      6:  ['The Golden Omen', 'A scarecrow of pure gold strides through the field. Legends say it hoards the straw of a hundred fallen farms. Cut it down and the harvest is yours.'],
+      15: ['Whispers of the Mages', 'Purple light flickers among the ranks. The scarecrows have learned to <b>blink</b> across the field. Whoever raised this army is teaching them sorcery.'],
+      30: ['The Magician\'s Wave', 'The sky splits violet. An entire legion of Magician Scarecrows teleports onto your soil at once. This is the enemy commander\'s masterstroke — survive it and their spell breaks.'],
+      50: ['Half a Hundred', 'Fifty waves. The northern fortress groans and cracks. You are no longer defending a farm — you are winning a war.'],
+      100:['The Final Harvest', 'Everything the fortress has left pours out in one last tide. Hold the line, farmer. Dawn is one wave away.'],
+    },
+    epilogue: [
+      'The last scarecrow crumbles to dry straw and blows away on the morning wind.',
+      'The blood-moon fades. Green returns to the fields.',
+      'Your family\'s farm still stands — and the story of the farmer who held the line will be told for three more generations.',
+    ],
+  },
+  jungle: {
+    title: '🌿 The Jungle Frontier',
+    intro: [
+      'You cleared a farm at the heart of the deep jungle, where no one was meant to settle.',
+      'The canopy did not forgive the intrusion. Now the monkey-clans swing from the vines with blowdarts and banana bombs, and something older stirs in the green dark.',
+      'Defend your clearing. The jungle is watching.',
+    ],
+    beats: {
+      5:  ['The Alpha Descends', 'The trees shudder. A massive alpha crashes down, and the smaller monkeys howl in answer. The clans have chosen a war-leader.'],
+      15: ['Poison in the Leaves', 'Darts fly thicker now, tipped with jungle venom. The clans have opened their oldest armories against you.'],
+      50: ['The Green Court', 'The jungle itself seems to lean inward. You have pushed the monkey-clans back to their sacred grove. They will not retreat again.'],
+      100:['Heart of the Canopy', 'Every vine, every clan, every beast converges on your clearing at once. Win here and the jungle finally makes peace.'],
+    },
+    epilogue: [
+      'The last war-drum falls silent. The monkeys retreat into the high canopy — not defeated, but respectful.',
+      'They leave a wreath of jungle flowers at the edge of your clearing.',
+      'You are no longer an intruder. You are the farmer the jungle chose to keep.',
+    ],
+  },
+  snow: {
+    title: '❄️ The Frozen Homestead',
+    intro: [
+      'The winter came early this year, and it never left.',
+      'From the white silence beyond the drifts, the snowmen march — hollow-eyed, coal-hearted, and endless. Their frost creeps toward your barn a little further each night.',
+      'Keep the fires burning. Outlast the cold.',
+    ],
+    beats: {
+      5:  ['The Frost Giant', 'The blizzard parts around a towering snow-brute. Where it walks, the ground freezes solid. The deep winter has sent its champion.'],
+      15: ['The Long Dark', 'The sun barely rises now. The snowmen move in the gloom, and the cold gnaws at the barn\'s timbers. Hold fast until the light returns.'],
+      50: ['The Thaw Begins', 'For the first time in months, an icicle drips. Fifty waves of winter, and still you stand. The frost is <b>losing</b>.'],
+      100:['The Last Blizzard', 'Winter throws everything into one final storm. Break it, and spring is yours to keep.'],
+    },
+    epilogue: [
+      'The final snowman melts into a quiet puddle at your doorstep.',
+      'Warm wind sweeps the drifts away. Green shoots push through the mud where the fields used to be.',
+      'You survived the winter that would not end. Spring belongs to you now.',
+    ],
+  },
+  deepsea: {
+    title: '🌊 The Abyssal Outpost',
+    intro: [
+      'No one builds a farm at the bottom of the sea. No one but you.',
+      'In the crushing dark, your bio-domes glow like a lonely lantern — and the things below have noticed. Sharks, krakens, and worse rise from the trench, drawn to your light.',
+      'Hold the outpost. The abyss is hungry.',
+    ],
+    beats: {
+      5:  ['The Trench Stirs', 'A shadow the size of the outpost glides past the lights. Something enormous has woken in the deep, and it is sending its children first.'],
+      15: ['The Kraken\'s Reach', 'Tentacles coil at the edge of the dome-light. The abyss no longer tests you — it means to drag the whole outpost down.'],
+      50: ['Into the Deep', 'The pressure eases; the creatures thin. You have pushed the abyss back toward its trench. Keep descending.'],
+      100:['The Abyss Roars', 'Everything in the trench surges upward in one final, lightless tide. Endure it, and the deep goes quiet at last.'],
+    },
+    epilogue: [
+      'The last leviathan sinks back into the dark, and the water goes still.',
+      'Bioluminescent gardens bloom around your domes — the abyss offering tribute to the light that would not go out.',
+      'You farmed the bottom of the world, and the world let you stay.',
+    ],
+  },
+};
+
+let _storyBeatTimer = null;
+function showStoryBeat(title, text, dur = 7000) {
+  const el = document.getElementById('story-beat');
+  if (!el) return;
+  document.getElementById('story-beat-title').innerHTML = title;
+  document.getElementById('story-beat-text').innerHTML = text;
+  el.classList.add('show');
+  if (_storyBeatTimer) clearTimeout(_storyBeatTimer);
+  _storyBeatTimer = setTimeout(() => el.classList.remove('show'), dur);
+}
+
+// Fire the story beat for the wave that is about to begin (if any)
+function triggerWaveStory(wave) {
+  const story = BIOME_STORY[gs.biome];
+  if (!story || !story.beats) return;
+  const beat = story.beats[wave];
+  if (beat) setTimeout(() => showStoryBeat('📜 ' + beat[0], beat[1]), 1400);
+}
+
 function showScreen(id) {
   const sc = document.getElementById('screen');
   const inn = document.getElementById('screen-inner');
   sc.classList.remove('hidden');
+  const _sb = document.getElementById('story-beat'); if (_sb) _sb.classList.remove('show');
   startTheme();
   if (id === 'menu') {
     inn.innerHTML = `<div class="stitle">🌱 Garden Farmers</div>
@@ -6100,7 +6216,7 @@ function showScreen(id) {
   } else if (id === 'skins') {
     inn.innerHTML = `<div class="stitle" style="font-size:38px">Choose Your Farmer</div>
       <div class="skin-grid" id="skg"></div>
-      <button class="bbtn" onclick="startGame()">Let's Go! ▶</button>
+      <button class="bbtn" onclick="showScreen('prologue')">Continue ▶</button>
       <button class="bbtn gray" onclick="showScreen('biome')">Back</button>`;
     const g = document.getElementById('skg');
     SKINS.forEach(s => {
@@ -6110,6 +6226,16 @@ function showScreen(id) {
       d.onclick = () => { gs.skin = s.id; document.querySelectorAll('.skin-card').forEach(c => c.classList.remove('sel')); d.classList.add('sel'); buildPlayerMesh(); };
       g.appendChild(d);
     });
+  } else if (id === 'prologue') {
+    const story = BIOME_STORY[gs.biome] || BIOME_STORY.garden;
+    const paras = story.intro.map(p => `<p style="margin:0 0 14px">${p}</p>`).join('');
+    inn.innerHTML = `
+      <div style="max-width:560px;margin:0 auto;padding:8px">
+        <div class="stitle" style="font-size:34px;color:#f5c977;text-shadow:0 0 30px rgba(245,201,119,0.4)">${story.title}</div>
+        <div style="font-size:15px;color:#e7dcc4;line-height:1.75;font-style:italic;text-align:left;background:linear-gradient(160deg,rgba(30,20,10,0.6),rgba(15,10,6,0.5));border:1px solid rgba(230,190,120,0.35);border-radius:14px;padding:20px 24px;margin:18px 0 22px">${paras}</div>
+        <button class="bbtn" style="background:linear-gradient(135deg,#c8901e,#8a5a10)" onclick="startGame()">Begin ▶</button>
+        <button class="bbtn gray" onclick="showScreen('skins')">◀ Back</button>
+      </div>`;
   } else if (id === 'gameover') {
     const en = getActiveData().enemyName;
     inn.innerHTML = `<div class="stitle" style="color:#f44">💀 ${gs.biome === 'snow' ? '🏔️' : gs.biome === 'jungle' ? '🌿' : '🌾'} Defeated!</div>
@@ -6119,8 +6245,11 @@ function showScreen(id) {
       <button class="bbtn gray" onclick="showScreen('menu')">Menu</button>`;
   } else if (id === 'victory') {
     const totalW = getActiveData().waves.length;
+    const story = BIOME_STORY[gs.biome] || BIOME_STORY.garden;
+    const epi = (story.epilogue || []).map(p => `<p style="margin:0 0 12px">${p}</p>`).join('');
     inn.innerHTML = `<div class="stitle">🏆 YOU WIN!</div>
       <div class="ssub">You survived all ${totalW} waves in the ${gs.biome === 'snow' ? 'Snowy Tundra' : gs.biome === 'jungle' ? 'Jungle Forest' : gs.biome === 'deepsea' ? 'Deep Sea Abyss' : 'Garden Farm'}!</div>
+      <div style="max-width:540px;margin:0 auto 16px;font-size:15px;color:#e7dcc4;line-height:1.7;font-style:italic;text-align:left;background:linear-gradient(160deg,rgba(30,20,10,0.55),rgba(15,10,6,0.45));border:1px solid rgba(230,190,120,0.3);border-radius:14px;padding:18px 22px">${epi}</div>
       <div style="color:#FFD700;font-size:20px;margin:10px">${getActiveData().resourceEmoji} ${gs.straw} | 💀 ${gs.totalKills} ${getActiveData().enemyName} defeated</div>
       <button class="bbtn" onclick="showScreen('menu')">Main Menu</button>`;
   } else if (id === 'saves') {


### PR DESCRIPTION
## What & why

The game had almost no narrative — just gameplay instructions. This adds a real story layer that unfolds as you play.

## Changes (`garden-farmers/index.html`)

- **`BIOME_STORY`** — per-biome lore for all four biomes (Garden, Jungle, Tundra, Deep Sea), each with an `intro`, keyed wave `beats`, and an `epilogue`.
- **Prologue screen** — a short narrative shown after you pick your farmer, before the first wave (the "Continue" button now leads here, then "Begin" starts the game).
- **Mid-run story beats** — a parchment banner (`#story-beat` + `showStoryBeat()`) that fires at key waves (first boss, golden scarecrow, mages, waves 30/50/100), triggered from `startNextWave`.
- **Molten Cavern lore** — its own story beat when you enter the cavern.
- **Victory epilogue** — the win screen now shows the biome's story ending.

## Verification

Rendered in a headless browser (Chromium): the prologue, an in-game wave beat, and the victory epilogue all display correctly, no page errors. Screenshots shared with the author.

Inline script passes `node --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N9myMx5hihZcbt4woqyi2b

---
_Generated by [Claude Code](https://claude.ai/code/session_01N9myMx5hihZcbt4woqyi2b)_