### PR TITLE
Garden Farmers: fix seven gameplay bugs (mobile placement, save/load, broken abilities)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Garden Farmers - Bug Fixes
+
+#### Fixed
+- **Mobile: purchased animals and defenses couldn't be placed between waves** — the place button and canvas taps were ignored while waiting for the next wave, exactly when players buy and place items (the straw was already spent). Tapping the ground in place mode now also plants directly at the tapped spot, matching desktop clicks
+- **Max HP upgrades were lost on reload** — the upgraded maximum was never saved, so a loaded game clamped you back to 100 max HP no matter how many upgrades you'd bought
+- **Poison carried over into a new game** — dying while poisoned by a jungle poison monkey left the poison ticking, so the next run started silently draining health
+- **Beehive and Crystal Shard never chained** — their advertised chain-attack now actually jumps between enemies (Beehive up to 6, Crystal Shard up to 8)
+- **Healing Swan never healed** — its splash now restores 12 HP to nearby placed plants and animals, as its description promises
+- Event banner no longer disappears when one event ends while another is still running, and it no longer rewrites the DOM every frame
+- Wild-bird fade-out no longer risks a crash on meshless children
+
 ### Garden Farmers - Performance Overhaul
 
 #### Fixed

--- a/garden-farmers/index.html
+++ b/garden-farmers/index.html
@@ -2730,8 +2730,11 @@ window.addEventListener('wheel', e => {
 
   document.getElementById('attack-btn').addEventListener('touchstart', e => {
     e.preventDefault();
-    if (!gameStarted || gs.betweenWaves) return;
-    if (gs.placeMode) placeAtMouse(); else { mouseHeld = true; doAttack(); }
+    if (!gameStarted) return;
+    // Placement must work between waves too — that's when items are bought
+    if (gs.placeMode) { placeAtMouse(); return; }
+    if (gs.betweenWaves) return;
+    mouseHeld = true; doAttack();
   }, { passive: false });
   document.getElementById('attack-btn').addEventListener('touchend', () => { mouseHeld = false; });
 
@@ -2747,13 +2750,15 @@ window.addEventListener('wheel', e => {
 
   // Canvas touch: update aim direction from finger position
   document.getElementById('c').addEventListener('touchstart', e => {
-    if (!gameStarted || gs.betweenWaves) return;
+    if (!gameStarted || (gs.betweenWaves && !gs.placeMode)) return;
     for (const t of e.changedTouches) {
       if (t.identifier !== joystick.id) {
         const mx = (t.clientX / window.innerWidth) * 2 - 1;
         const my = -(t.clientY / window.innerHeight) * 2 + 1;
         raycaster.setFromCamera({ x: mx, y: my }, camera);
         raycaster.ray.intersectPlane(groundPlane, mouseWorld);
+        // In place mode a tap on the ground plants right there, like a desktop click
+        if (gs.placeMode) placeAtMouse();
         break;
       }
     }
@@ -3134,7 +3139,7 @@ function spawnProj(pos, dir, spd, data, owner, life) {
       m = new THREE.Mesh(new THREE.SphereGeometry(0.24, 8, 8), em(col));
   }
   m.position.copy(pos); scene.add(m);
-  gs.projectiles.push({ mesh: m, pos: pos.clone(), vel: dir.clone().multiplyScalar(spd), data, owner, timer: life, hitSet: new Set(), bounceLeft: data.bounces || 0, _trailT: 0 });
+  gs.projectiles.push({ mesh: m, pos: pos.clone(), vel: dir.clone().multiplyScalar(spd), data, owner, timer: life, hitSet: new Set(), bounceLeft: data.bounces || data.chains || 0, _trailT: 0 });
 }
 
 function dmgEnemy(e, dmg) {
@@ -4151,21 +4156,27 @@ const eventText   = document.getElementById('event-text');
 const eventTimerBar = document.getElementById('event-timer-bar');
 let _eventBannerTimeout = null;
 
+let _bannerEvId = null;
 function showEventBanner(ev, remaining, total) {
-  eventText.textContent = ev.name + ' — ' + ev.desc;
-  eventBanner.className = 'show' + (ev.bad ? ' bad' : '');
+  // Only rewrite the banner DOM when the shown event changes — this is
+  // called every frame while an event is active.
+  if (_bannerEvId !== ev.id) {
+    _bannerEvId = ev.id;
+    eventText.textContent = ev.name + ' — ' + ev.desc;
+    eventBanner.className = 'show' + (ev.bad ? ' bad' : '');
+    eventTimerBar.style.display = ev.instant ? 'none' : 'block';
+  }
   if (ev.instant) {
-    eventTimerBar.style.display = 'none';
     clearTimeout(_eventBannerTimeout);
-    _eventBannerTimeout = setTimeout(() => { eventBanner.className = ''; }, 3000);
+    _eventBannerTimeout = setTimeout(() => { eventBanner.className = ''; _bannerEvId = null; }, 3000);
   } else {
-    eventTimerBar.style.display = 'block';
     eventTimerBar.style.width = (remaining / total * 100) + '%';
   }
 }
 
 function hideEventBanner() {
   eventBanner.className = '';
+  _bannerEvId = null;
 }
 
 function triggerRandomEvent() {
@@ -4216,7 +4227,8 @@ function updateEventSystem(dt) {
     gs.activeEvents[id] -= dt;
     if (gs.activeEvents[id] <= 0) {
       delete gs.activeEvents[id];
-      hideEventBanner();
+      if (Object.keys(gs.activeEvents).length === 0) hideEventBanner();
+      else _bannerEvId = null; // let the next still-active event repaint the banner
     } else {
       anyActive = true;
       const ev = RANDOM_EVENTS.find(e => e.id === id);
@@ -5507,6 +5519,15 @@ function updatePlacedPlants(dt) {
               spawnFX(e.pos.clone(), 0x44aaff, 0.3, 0.6);
             }
           });
+          // Healing Swan: the splash also heals nearby placed friends, as advertised
+          if (p.data.id === 'swan') {
+            gs.placedPlants.forEach(fp => {
+              if (fp !== p && fp.hp < fp.maxHp && fp.pos.distanceTo(p.pos) < p.data.range) {
+                fp.hp = Math.min(fp.maxHp, fp.hp + 12);
+                spawnFX(fp.pos.clone().add(new THREE.Vector3(0, 1, 0)), 0x66ff99, 0.35, 0.7);
+              }
+            });
+          }
           spawnFX(p.pos.clone(), 0x44aaff, 0.45, p.data.range * 0.4);
           sfxSplat();
 
@@ -5698,7 +5719,7 @@ function updateWildBirds(dt) {
     // Fade out last 5 seconds
     if (b.life < 5) {
       const op = b.life / 5;
-      b.mesh.children.forEach(c => { if (c.material) c.material.transparent = true; c.material.opacity = op; });
+      b.mesh.children.forEach(c => { if (c.material) { c.material.transparent = true; c.material.opacity = op; } });
     }
     return true;
   });
@@ -6584,7 +6605,7 @@ function saveGame() {
     const data = {
       straw: gs.straw, wave: gs.wave, skin: gs.skin, biome: gs.biome,
       barnHP: gs.barnHP, barnMaxHP: gs.barnMaxHP, barnCannons: gs.barnCannons,
-      playerHP: gs.playerHP, totalKills: gs.totalKills,
+      playerHP: gs.playerHP, playerMaxHP: gs.playerMaxHP, totalKills: gs.totalKills,
       ownedWeapons: [...gs.ownedWeapons], ownedPlaceables: [...gs.ownedPlaceables],
       hotbar: gs.hotbar, farmExpansions: gs.farmExpansions,
       savedAt: new Date().toISOString(),
@@ -6609,7 +6630,9 @@ function loadGame() {
     gs.barnHP = d.barnHP || 200; gs.barnMaxHP = d.barnMaxHP || 200;
     gs.barnCannons = d.barnCannons || 0;
     for (let i = 1; i <= gs.barnCannons; i++) addBarnCannonMesh(i);
-    gs.playerHP = d.playerHP || 100; gs.totalKills = d.totalKills || 0;
+    gs.playerMaxHP = d.playerMaxHP || 100;
+    gs.playerHP = Math.min(d.playerHP || 100, gs.playerMaxHP);
+    gs.totalKills = d.totalKills || 0;
     gs.ownedWeapons = new Set(d.ownedWeapons || ['carrot']);
     gs.ownedPlaceables = new Set(d.ownedPlaceables || []);
     gs.hotbar = d.hotbar || ['carrot', null, null, null, null];
@@ -6905,7 +6928,7 @@ function resetGame() {
   gs.ownedWeapons = new Set([_starter]); gs.ownedPlaceables = new Set();
   gs.hotbar = [_starter, null, null, null, null]; gs.activeSlot = 0;
   gs.totalKills = 0; attackCd = 0;
-  gs.playerSlowTimer = 0;
+  gs.playerSlowTimer = 0; gs.playerPoisonTimer = 0;
   gs.eventTimer = 90; gs.activeEvents = {}; gs._strawRainTick = 0;
   _merchantTimer = 420; _merchantActive = false; _merchantDuration = 0; _merchantStock = [];
   if (_inForest) {


### PR DESCRIPTION
## Why

Follow-up review pass over Garden Farmers after the performance overhaul (#117), this time hunting functional bugs. Seven found, all fixed.

## Bugs fixed

1. **Mobile players couldn't place purchased animals/defenses between waves.** The place button (▶) and canvas taps both bailed out whenever `gs.betweenWaves` was set — but between waves is exactly when you buy and place items, and the straw was already spent at purchase. Placement taps now work between waves, and tapping the ground in place mode plants directly at the tapped spot (matching desktop clicks).
2. **Max HP upgrades were lost on save/load.** `playerMaxHP` was never saved, so "+25 max HP permanently" upgrades vanished on reload. Now saved, and loaded HP is clamped to the loaded max.
3. **Poison carried into a new game.** `resetGame` never cleared `playerPoisonTimer`, so dying while poisoned (jungle poison monkey) left the next run silently draining 4 HP/s.
4. **Beehive and Crystal Shard never chained.** Their shop descriptions promise chaining to 6/8 enemies, but the `chains` stat was never wired into the projectile system. It now feeds the existing bounce mechanic.
5. **Healing Swan never healed.** Its description promises "+12 HP to placed friends"; it only ran the generic water splash. The splash now also heals nearby placed plants/animals.
6. **Event banner bugs.** One event expiring hid the banner even when another event was still running; also the banner DOM (text, class, width) was rewritten every single frame — now only the timer bar updates per frame, and full repaints happen only when the displayed event changes.
7. **Latent crash in wild-bird fade-out** — `c.material.opacity` was written outside the `if (c.material)` guard.

## Verification (headless Chromium + Playwright, driving the real game)

| Test | Result |
|---|---|
| Save at max HP 150 → reload | max HP 150 restored, HP ≤ max — PASS |
| Die poisoned → new game | poison timer 0 — PASS |
| Beehive projectile | carries 6 bounces (was 0) — PASS |
| Swan splash near wounded cactus | HP 10 → 46 — PASS |
| Two events, one expires | banner stays for the survivor — PASS |
| Buy defense between waves → place | placed successfully — PASS |
| Full combat wave soak | zero page errors, GPU resources flat — PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQaRT3fCyukFjtPx5ZF7cw

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQaRT3fCyukFjtPx5ZF7cw)_